### PR TITLE
Prepping 1.25.0 Release

### DIFF
--- a/io.embrace.sdk/CHANGELOG.md
+++ b/io.embrace.sdk/CHANGELOG.md
@@ -5,6 +5,14 @@ sidebar_position: 4
 ---
 
 # Unity SDK Changelog
+## 1.25.0
+*April 19, 2024*
+:::warning Important
+This version of the Unity SDK requires a later version than 2021.3.16f1. It is tested working on 2021.3.37f1 (the latest LTS version at time of writing). If you receive a "transformer returned null" error of some kind during your build process, please upgrade your LTS engine version.
+:::
+
+* Upgrade Embrace Android Plugin to Android 6.5.0
+
 ## 1.24.0
 *March 17, 2024*
 :::warning Important

--- a/io.embrace.sdk/Resources/Info/EmbraceSdkInfo.json
+++ b/io.embrace.sdk/Resources/Info/EmbraceSdkInfo.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.24.0",
+  "version": "1.25.0",
   "npmAPIEndpoint": "https://repo.embrace.io/repository/unity",
   "wAnnouncementTitle": "iOS Configuration Update",
   "wAnnouncementMessage": "The CRASH_REPORT_ENABLED setting has been replaced by CRASH_REPORT_PROVIDER. Any existing configuration will be migrated automatically, but please take a moment to double check the value in the Embrace settings window."

--- a/io.embrace.sdk/package.json
+++ b/io.embrace.sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io.embrace.sdk",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "displayName": "Embrace SDK",
   "description": "Embrace's Unity SDK lets you bring the deep, introspective and native debugging power of Embrace into your Unity game or application.",
   "unity": "2019.1",


### PR DESCRIPTION
## Goal

Release Unity 1.25.0 with Embrace Android 6.5.0 upgrade

## Testing

Tested in the 6.5.0 branch that was merged.

## Release Notes

## 1.25.0
*April 19, 2024*
:::warning Important
This version of the Unity SDK requires a later version than 2021.3.16f1. It is tested working on 2021.3.37f1 (the latest LTS version at time of writing). If you receive a "transformer returned null" error of some kind during your build process, please upgrade your LTS engine version.
:::

* Upgrade Embrace Android Plugin to Android 6.5.0

**WHAT**: Release upgrade Embrace Android Plugin to Android 6.5.0
**WHY**: To bring the latest Embrace Android offerings to customers in the Unity SDK
**WHO**: Embrace Android customers
