### PR TITLE
Properly disposing Android objects and classes

### DIFF
--- a/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
+++ b/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
@@ -193,16 +193,16 @@ namespace EmbraceSDK.Internal
             EmbraceLogger.Log("Embrace Unity SDK initializing java objects");
             CacheJavaMapPointers();
             CacheJavaNativeObjectTypes();
-            AndroidJavaClass unityPlayerClass = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
-            AndroidJavaObject activityInstance = unityPlayerClass.GetStatic<AndroidJavaObject>("currentActivity");
+            using AndroidJavaClass unityPlayerClass = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+            using AndroidJavaObject activityInstance = unityPlayerClass.GetStatic<AndroidJavaObject>("currentActivity");
             applicationInstance = activityInstance.Call<AndroidJavaObject>("getApplication");
             embraceClass = new AndroidJavaClass("io.embrace.android.embracesdk.Embrace");
             EmbraceSharedInstance = embraceClass.CallStatic<AndroidJavaObject>("getInstance");
             // get the app framework object
-            AndroidJavaClass appFramework = new AndroidJavaClass("io.embrace.android.embracesdk.Embrace$AppFramework");
+            using AndroidJavaClass appFramework = new AndroidJavaClass("io.embrace.android.embracesdk.Embrace$AppFramework");
             unityAppFramework = appFramework.GetStatic<AndroidJavaObject>("UNITY");
             // get the log severity objects
-            AndroidJavaClass logSeverity = new AndroidJavaClass("io.embrace.android.embracesdk.Severity");
+            using AndroidJavaClass logSeverity = new AndroidJavaClass("io.embrace.android.embracesdk.Severity");
             logInfo = logSeverity.GetStatic<AndroidJavaObject>("INFO");
             logWarning = logSeverity.GetStatic<AndroidJavaObject>("WARNING");
             logError = logSeverity.GetStatic<AndroidJavaObject>("ERROR");
@@ -217,7 +217,7 @@ namespace EmbraceSDK.Internal
         void IEmbraceProvider.EndAppStartup(Dictionary<string, string> properties)
         {
             if (!ReadyForCalls()) { return; }
-            AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
+            using AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
             EmbraceSharedInstance?.Call(_EndAppStartupMethod, javaMap);
         }
 
@@ -227,7 +227,7 @@ namespace EmbraceSDK.Internal
 
             try
             {
-                AndroidJavaObject lastRunStateObject = EmbraceSharedInstance?.Call<AndroidJavaObject>(_GetLastRunEndStateMethod);
+                using AndroidJavaObject lastRunStateObject = EmbraceSharedInstance?.Call<AndroidJavaObject>(_GetLastRunEndStateMethod);
                 int lastRunStateInt = lastRunStateObject.Call<int>(_LastRunEndStateGetValueMethod);
 
                 switch (lastRunStateInt)
@@ -351,7 +351,7 @@ namespace EmbraceSDK.Internal
         {
             if (!ReadyForCalls()) { return null; }
 
-            AndroidJavaObject javaMap = EmbraceSharedInstance?.Call<AndroidJavaObject>(_GetSessionPropertiesMethod);
+            using AndroidJavaObject javaMap = EmbraceSharedInstance?.Call<AndroidJavaObject>(_GetSessionPropertiesMethod);
 
             // The Android SDK can return null if this function is called before the SDK is initialized, or if SDK
             // initialization fails. In this case, return an empty dictionary to match behavior on iOS.
@@ -367,21 +367,21 @@ namespace EmbraceSDK.Internal
         void IEmbraceProvider.StartMoment(string name, string identifier, bool allowScreenshot, Dictionary<string, string> properties)
         {
             if (!ReadyForCalls()) { return; }
-            AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
+            using AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
             EmbraceSharedInstance?.Call(_StartEventMethod, name, identifier, javaMap);
         }
 
         void IEmbraceProvider.EndMoment(string name, string identifier, Dictionary<string, string> properties)
         {
             if (!ReadyForCalls()) { return; }
-            AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
+            using AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
             EmbraceSharedInstance?.Call(_EndEventMethod, name, identifier, javaMap);
         }
 
         void IEmbraceProvider.LogMessage(string message, EMBSeverity severity, Dictionary<string, string> properties)
         {
             if (!ReadyForCalls()) { return; }
-            AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
+            using AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
 
             switch (severity)
             {
@@ -502,13 +502,13 @@ namespace EmbraceSDK.Internal
         {
             if (!ReadyForCalls()) { return; }
 
-            var jNotificationPriority =
+            using AndroidJavaObject jNotificationPriority =
                 integerClass.CallStatic<AndroidJavaObject>("valueOf", androidArgs.notificationPriority);
-            var jMessageDeliveredPriority = 
+            using AndroidJavaObject jMessageDeliveredPriority = 
                 integerClass.CallStatic<AndroidJavaObject>("valueOf", androidArgs.messageDeliveredPriority);
             
-            var jIsNotification = booleanClass.CallStatic<AndroidJavaObject>("valueOf", androidArgs.isNotification);
-            var jHasData = booleanClass.CallStatic<AndroidJavaObject>("valueOf", androidArgs.hasData);
+            using AndroidJavaObject jIsNotification = booleanClass.CallStatic<AndroidJavaObject>("valueOf", androidArgs.isNotification);
+            using AndroidJavaObject jHasData = booleanClass.CallStatic<AndroidJavaObject>("valueOf", androidArgs.hasData);
             
             EmbraceSharedInstance?.Call(_LogPushNotification, androidArgs.title, androidArgs.body, androidArgs.topic, androidArgs.id,
                 jNotificationPriority, jMessageDeliveredPriority, jIsNotification, jHasData);


### PR DESCRIPTION
## Goal

Properly disposing Android objects and classes on Native_Android class. Not disposing it made the code more prone to crash due the memory being partially held or not fully cleaned

## Testing
Part of the changes are live on Tennis Clash but IEmbraceProvider.RecordPushNotification isn't properly tested yet
