### PR TITLE
XCFramework/Framework iOS Meta File Updates

### DIFF
--- a/io.embrace.sdk/iOS/Embrace.xcframework.meta
+++ b/io.embrace.sdk/iOS/Embrace.xcframework.meta
@@ -1,8 +1,72 @@
 fileFormatVersion: 2
 guid: 2bd2887e52a04430ab88cb19b579ddf5
-folderAsset: yes
-DefaultImporter:
+PluginImporter:
   externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        'Exclude ': 1
+        Exclude Android: 1
+        Exclude BlackBerry: 1
+        Exclude CloudRendering: 1
+        Exclude EmbeddedLinux: 1
+        Exclude GameCoreScarlett: 1
+        Exclude GameCoreXboxOne: 1
+        Exclude Linux: 1
+        Exclude Linux64: 1
+        Exclude LinuxUniversal: 1
+        Exclude Lumin: 1
+        Exclude N3DS: 1
+        Exclude OSXIntel: 1
+        Exclude OSXIntel64: 1
+        Exclude OSXUniversal: 1
+        Exclude PS3: 1
+        Exclude PS4: 1
+        Exclude PS5: 1
+        Exclude PSM: 1
+        Exclude PSP2: 1
+        Exclude SamsungTV: 1
+        Exclude Stadia: 1
+        Exclude Switch: 1
+        Exclude Tizen: 1
+        Exclude WP8: 1
+        Exclude Web: 1
+        Exclude WebGL: 1
+        Exclude WebStreamed: 1
+        Exclude WiiU: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude WindowsStoreApps: 1
+        Exclude XboxOne: 1
+        Exclude iOS: 1
+        Exclude tvOS: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/io.embrace.sdk/iOS/Embrace.xcframework/ios-arm64_armv7/Embrace.framework.meta
+++ b/io.embrace.sdk/iOS/Embrace.xcframework/ios-arm64_armv7/Embrace.framework.meta
@@ -1,6 +1,5 @@
 fileFormatVersion: 2
 guid: 976d4508ef57e464cad9d9b792d737cf
-folderAsset: yes
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -37,10 +36,12 @@ PluginImporter:
         Exclude PS5: 1
         Exclude PSM: 1
         Exclude PSP2: 1
+        Exclude QNX: 1
         Exclude SamsungTV: 1
         Exclude Stadia: 1
         Exclude Switch: 1
         Exclude Tizen: 1
+        Exclude VisionOS: 1
         Exclude WP8: 1
         Exclude Web: 1
         Exclude WebGL: 1
@@ -63,6 +64,11 @@ PluginImporter:
       enabled: 0
       settings:
         DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/io.embrace.sdk/iOS/Embrace.xcframework/ios-arm64_i386_x86_64-simulator/Embrace.framework.meta
+++ b/io.embrace.sdk/iOS/Embrace.xcframework/ios-arm64_i386_x86_64-simulator/Embrace.framework.meta
@@ -1,6 +1,5 @@
 fileFormatVersion: 2
 guid: c6972a1d1d44f4c779ceb73388251a8b
-folderAsset: yes
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -37,10 +36,12 @@ PluginImporter:
         Exclude PS5: 1
         Exclude PSM: 1
         Exclude PSP2: 1
+        Exclude QNX: 1
         Exclude SamsungTV: 1
         Exclude Stadia: 1
         Exclude Switch: 1
         Exclude Tizen: 1
+        Exclude VisionOS: 1
         Exclude WP8: 1
         Exclude Web: 1
         Exclude WebGL: 1
@@ -63,6 +64,11 @@ PluginImporter:
       enabled: 0
       settings:
         DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/io.embrace.sdk/iOS/Embrace.xcframework/tvos-arm64/Embrace.framework.meta
+++ b/io.embrace.sdk/iOS/Embrace.xcframework/tvos-arm64/Embrace.framework.meta
@@ -1,6 +1,5 @@
 fileFormatVersion: 2
 guid: e3e6f2bfe8f9f42a688fccc8934f9446
-folderAsset: yes
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -37,10 +36,12 @@ PluginImporter:
         Exclude PS5: 1
         Exclude PSM: 1
         Exclude PSP2: 1
+        Exclude QNX: 1
         Exclude SamsungTV: 1
         Exclude Stadia: 1
         Exclude Switch: 1
         Exclude Tizen: 1
+        Exclude VisionOS: 1
         Exclude WP8: 1
         Exclude Web: 1
         Exclude WebGL: 1
@@ -63,6 +64,11 @@ PluginImporter:
       enabled: 0
       settings:
         DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/io.embrace.sdk/iOS/Embrace.xcframework/tvos-arm64_x86_64-simulator/Embrace.framework.meta
+++ b/io.embrace.sdk/iOS/Embrace.xcframework/tvos-arm64_x86_64-simulator/Embrace.framework.meta
@@ -1,6 +1,5 @@
 fileFormatVersion: 2
 guid: 1bb30015aeda04b468b42986ad9ff898
-folderAsset: yes
 PluginImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -37,10 +36,12 @@ PluginImporter:
         Exclude PS5: 1
         Exclude PSM: 1
         Exclude PSP2: 1
+        Exclude QNX: 1
         Exclude SamsungTV: 1
         Exclude Stadia: 1
         Exclude Switch: 1
         Exclude Tizen: 1
+        Exclude VisionOS: 1
         Exclude WP8: 1
         Exclude Web: 1
         Exclude WebGL: 1
@@ -63,6 +64,11 @@ PluginImporter:
       enabled: 0
       settings:
         DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
## Goal

Appropriately mark the iOS plugin files for Embrace to prevent them from interfering on Android

## Testing

Observed appropriate meta file settings

## Release Notes

This should deal with the Android build blocking issue where the iOS frameworks need to be set up to be ignored on Android.
