### PR TITLE
Version update and changelog notes for 1.25.3

### DIFF
--- a/io.embrace.sdk/CHANGELOG.md
+++ b/io.embrace.sdk/CHANGELOG.md
@@ -5,6 +5,19 @@ sidebar_position: 4
 ---
 
 # Unity SDK Changelog
+## 1.25.3
+*June 24, 2024*
+* Patch to PBXProject generation on 2021 and later around linker phase construction.
+* Patch to iOS xcframework and framework plugin matrix platform labeling.
+
+## 1.25.2
+*May 23, 2024*
+* Defensive patch of null case provider issue.
+
+## 1.25.1
+*April 25, 2024*
+* Patch of issue on newer versions of Unity iOS that involved double injecting into the linker phase
+
 ## 1.25.0
 *April 19, 2024*
 :::warning Important

--- a/io.embrace.sdk/Resources/Info/EmbraceSdkInfo.json
+++ b/io.embrace.sdk/Resources/Info/EmbraceSdkInfo.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.25.0",
+  "version": "1.25.3",
   "npmAPIEndpoint": "https://repo.embrace.io/repository/unity",
   "wAnnouncementTitle": "iOS Configuration Update",
   "wAnnouncementMessage": "The CRASH_REPORT_ENABLED setting has been replaced by CRASH_REPORT_PROVIDER. Any existing configuration will be migrated automatically, but please take a moment to double check the value in the Embrace settings window."

--- a/io.embrace.sdk/package.json
+++ b/io.embrace.sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io.embrace.sdk",
-  "version": "1.25.0",
+  "version": "1.25.3",
   "displayName": "Embrace SDK",
   "description": "Embrace's Unity SDK lets you bring the deep, introspective and native debugging power of Embrace into your Unity game or application.",
   "unity": "2019.1",


### PR DESCRIPTION
## Goal

Prepping release for 1.25.3
Includes:

- Patch to PBXProject generation on 2021.3 and later around linker phase construction.
- Patch to iOS xcframework and framework plugin matrix platform labeling.

## Testing

Both changes tested before merging into main on their own branches.

## Release Notes

- Patch to PBXProject generation on 2021.3 and later around linker phase construction.
- Patch to iOS xcframework and framework plugin matrix platform labeling.
