### PR TITLE
Catch null attributes map when recording completed span on Android

### DIFF
--- a/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
+++ b/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
@@ -617,10 +617,11 @@ namespace EmbraceSDK.Internal
             }
 
             var dict = DictionariesToJavaListOfMaps(spanEvents, out var disposables);
+            var attDict = DictionaryToJavaMap(attributes);
             
             var result = _embraceInternalSharedInstance.Call<bool>(_RecordCompleteSpanMethod, spanName, startTimeMs,
                 endTimeMs, errorCode != null ? GetSpanErrorCode(errorCode.Value) : null, 
-                parentSpanId, DictionaryToJavaMap(attributes), dict);
+                parentSpanId, attDict, dict);
             
             foreach (var disposable in disposables)
             {
@@ -654,6 +655,12 @@ namespace EmbraceSDK.Internal
         {
             AndroidJavaObject map = new AndroidJavaObject("java.util.HashMap");
             IntPtr putMethod = AndroidJNIHelper.GetMethodID(map.GetRawClass(), "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
+            if (dictionary == null)
+            {
+                return map;
+            }
+
             foreach (var entry in dictionary)
             {
                 AndroidJNI.CallObjectMethod(


### PR DESCRIPTION
## Goal

Android JNI: Catch an NPE exception if a null attribute map is set as an argument when recording a completed span

## Testing

Tested locally using current Integration Scene recording a completed span with null attributes.

## Release Notes

Patched an issue with the Record completed span API on Android.

**WHAT**:<br> Patched an issue with the Record completed span API on Android.
**WHY**:<br> NPE exception happens if a null attribute map is set as an argument when recording a completed span
**WHO**:<br> Gameplay Galaxy and any other Unity Android customer that wants to record completed spans without attributes.
