### PR TITLE
Update swiftRef to main branch

### DIFF
--- a/io.embrace.sdk/Resources/Info/EmbraceSdkInfo.json
+++ b/io.embrace.sdk/Resources/Info/EmbraceSdkInfo.json
@@ -1,6 +1,6 @@
 {
   "version": "2.1.2",
-  "swiftRef": "branch:nathan.ostgard/spm",
+  "swiftRef": "branch:main",
   "npmAPIEndpoint": "https://repo.embrace.io/repository/unity",
   "wAnnouncementTitle": "Welcome to Embrace Unity SDK 2.0",
   "wAnnouncementMessage": "Now supporting the Otel compliant Embrace Android and Embrace iOS SDKs"


### PR DESCRIPTION
This is a follow up to #47. Once that has been merged to main, the `swiftRef` override should point to main instead of the temporary branch.

Note that this `swiftRef` will not be used for builds, as the property gets deleted by CI to ensure that the built version matches the tag. 