### PR TITLE
Update embrace-apple-sdk to v6.7.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/embrace-io/embrace-apple-sdk.git",
       "state" : {
-        "revision" : "2d36b95420e7b4fdb0d75ebde34abf5f75cc0e66",
-        "version" : "6.6.0"
+        "revision" : "14ff0a36ee42bb23036d33564d013b81a8ca1140",
+        "version" : "6.7.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "EmbraceUnityiOS", targets: ["EmbraceUnityiOS"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/embrace-io/embrace-apple-sdk.git", exact: "6.6.0")
+        .package(url: "https://github.com/embrace-io/embrace-apple-sdk.git", exact: "6.7.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
This updates the embrace-apple-sdk from v6.6.0 to v6.7.1. Changes to the underlying SDK include:

* Features
    * Improvements to the Automatic View Capture functionality, allowing attributes to be added to traces (`TTFR` and `TTI`) using the `addAttributesToTrace(_:)` method.
* Fixes
    * Fixed an issue causing crashes in views controllers with very short lifecycles (particularly in hosting controllers acting as internal bridges in SwiftUI).
    * Fixed a bug causing compilation issues related to the use of `DispatchQueue`.
    * Fixed an issue that caused the crash `'Cannot form weak reference to instance X of class Y'`.
    * Fixed an issue that prevented enabling/disabling certain functionalities.
    * Fixed incompatibility issues with AppLovin.