### PR TITLE
Add Windows test workflow

### DIFF
--- a/.github/actions/unity-test/action.yml
+++ b/.github/actions/unity-test/action.yml
@@ -51,6 +51,11 @@ runs:
       shell: bash
       run: |
         brew install --cask unity-hub
+    - name: Install Unity Hub (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        powershell.exe -ExecutionPolicy Bypass -File .github/scripts/install_unity_hub.ps1
     # These steps handle running for a single build target (used by the Linux
     # tests, which run in parallel).
     - name: Install editor

--- a/.github/scripts/install_unity_hub.ps1
+++ b/.github/scripts/install_unity_hub.ps1
@@ -1,0 +1,19 @@
+$hubInstallerUrl = "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.exe"
+$downloadPath = "$env:TEMP\UnityInstaller"
+if (!(Test-Path $downloadPath)) {
+    New-Item -ItemType Directory -Path $downloadPath | Out-Null
+}
+Write-Host "Downloading Unity Hub installer"
+& aria2c --quiet --max-connection-per-server=4 --dir $downloadPath $hubInstallerUrl
+if ($LASTEXITCODE) {
+    Write-Error "Failed to download Unity Hub installer"
+    exit $LASTEXITCODE
+}
+Write-Host "Installing Unity Hub"
+$process = Start-Process -FilePath "$downloadPath\UnityHubSetup.exe" -ArgumentList "/S" -NoNewWindow -PassThru
+Wait-Process -Id $process.Id
+if ($LASTEXITCODE) {
+    Write-Error "Failed to install Unity Hub"
+    exit $LASTEXITCODE
+}
+Write-Host "Unity Hub installed successfully"

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -9,7 +9,7 @@ import re
 import sys
 from os import path
 from subprocess import check_output, run
-from typing import get_args, Literal, TypeGuard
+from typing import get_args, Literal, Optional, TypeGuard
 
 
 logger = logging.getLogger("release")
@@ -29,14 +29,14 @@ version_filenames = [
 
 
 class InvalidRefTypeError(ValueError):
-    def __init__(self, ref_type: str | None) -> None:
+    def __init__(self, ref_type: Optional[str]) -> None:
         super().__init__(
             f"GITHUB_REF_TYPE is {ref_type!r}, but expected {get_args(RefType)!r}"
         )
 
 
 class InvalidRefNameError(ValueError):
-    def __init__(self, ref_name: str | None, pattern: str) -> None:
+    def __init__(self, ref_name: Optional[str], pattern: str) -> None:
         super().__init__(
             f"GITHUB_REF_NAME is {ref_name!r}, but expected pattern {pattern}"
         )
@@ -62,7 +62,7 @@ def commit_and_push(ref_name: str, version: str) -> str:
     return check_output(["git", "rev-parse", "HEAD"], text=True).strip()
 
 
-def is_ref_type(ref_type: str | None) -> TypeGuard[RefType]:
+def is_ref_type(ref_type: Optional[str]) -> TypeGuard[RefType]:
     return ref_type in get_args(RefType)
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,7 @@ jobs:
     needs:
       - test_linux
       - test_macos
+      - test_windows
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false
+      windows:
+        description: Run tests on Windows editor
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       ref:
@@ -30,6 +35,11 @@ on:
         default: true
       macos:
         description: Run tests on macOS editor
+        required: false
+        type: boolean
+        default: false
+      windows:
+        description: Run tests on Windows editor
         required: false
         type: boolean
         default: false
@@ -84,13 +94,40 @@ jobs:
     needs:
       - get_editor_versions
       - test_linux
-    if: ${{ inputs.macos == true }}
+    if: ${{ inputs.macos == true && !failure() && !cancelled() }}
     strategy:
       max-parallel: 1
       matrix:
         editor: ${{ fromJSON(needs.get_editor_versions.outputs.editor_versions) }}
     name: Test macOS (${{ matrix.editor.project }})
     runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          ref: ${{ inputs.ref }}
+      - name: Run tests
+        uses: ./.github/actions/unity-test
+        with:
+          editor_version: ${{ matrix.editor.version }}
+          editor_changeset: ${{ matrix.editor.changeset }}
+          license_email: ${{ secrets.UNITY_EMAIL }}
+          license_password: ${{ secrets.UNITY_PASSWORD }}
+          license_serial: ${{ secrets.UNITY_SERIAL }}
+          project: ${{ matrix.editor.project }}
+  test_windows:
+    needs:
+      - get_editor_versions
+      - test_linux
+      - test_macos
+    if: ${{ inputs.windows == true && !failure() && !cancelled() }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        editor: ${{ fromJSON(needs.get_editor_versions.outputs.editor_versions) }}
+    name: Test Windows (${{ matrix.editor.project }})
+    runs-on: windows-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/io.embrace.internal/Testing/Edit Mode Tests/PostBuildProcessorTests.cs
+++ b/io.embrace.internal/Testing/Edit Mode Tests/PostBuildProcessorTests.cs
@@ -138,7 +138,7 @@ namespace EmbraceSDK.Tests
         /// <summary>
         /// Test Android build.
         /// </summary>
-        [Test, Order(1), Timeout(300_000)]
+        [Test, Order(1), Timeout(600_000)]
 #if UNITY_EDITOR_OSX
         // CPU lightmapping is not supported on macOS arm64, and recompiling
         // scripts seems to trigger this to happen, causing an error which causes


### PR DESCRIPTION
This adds support for running unit tests on Windows. Like macOS, these tests are not run by default but can be run when manually triggering the workflow.