### PR TITLE
Update GitHub actions to use the Makefile when appropriate

### DIFF
--- a/.github/actions/unity-test/action.yml
+++ b/.github/actions/unity-test/action.yml
@@ -28,6 +28,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set environment variables from inputs
+      shell: bash
+      env:
+        BUILD_TARGET: ${{ inputs.build_target }}
+        EDITOR_CHANGESET: ${{ inputs.editor_changeset }}
+        EDITOR_VERSION: ${{ inputs.editor_version }}
+      run: |
+        make github_env_vars | tee -a $GITHUB_ENV
     - name: Cache Library folder
       uses: actions/cache@v4
       with:
@@ -41,53 +49,22 @@ runs:
       shell: bash
       run: |
         make install_ios_dependencies
-    - name: Install Unity Hub (Linux)
-      if: ${{ runner.os == 'Linux' }}
+    - name: Install Unity Hub
       shell: bash
       run: |
-        ./.github/scripts/install_hub_linux.sh
-    - name: Install Unity Hub (macOS)
-      if: ${{ runner.os == 'macOS' }}
-      shell: bash
-      run: |
-        brew install --cask unity-hub
-    - name: Install Unity Hub (Windows)
-      if: ${{ runner.os == 'Windows' }}
-      shell: pwsh
-      run: |
-        powershell.exe -ExecutionPolicy Bypass -File .github/scripts/install_unity_hub.ps1
-    # These steps handle running for a single build target (used by the Linux
-    # tests, which run in parallel).
+        make install_hub
     - name: Install editor
-      if: ${{ inputs.build_target != '' }}
       shell: bash
       run: |
-        python3 .github/scripts/unity.py --version ${{ inputs.editor_version }} install --changeset ${{ inputs.editor_changeset }} --module ${{ inputs.build_target }}
+        make install_editor
     - name: Run tests
-      if: ${{ inputs.build_target != '' }}
       shell: bash
       env:
         UNITY_EMAIL: ${{ inputs.license_email }}
         UNITY_PASSWORD: ${{ inputs.license_password }}
         UNITY_SERIAL: ${{ inputs.license_serial }}
       run: |
-        python3 .github/scripts/unity.py --version ${{ inputs.editor_version }} test --build-target ${{ inputs.build_target }}
-    # These steps handle running for all build targets (used by non-Linux tests,
-    # which run a single job since they can't handle multiple activations).
-    - name: Install editor (all build targets)
-      if: ${{ inputs.build_target == '' }}
-      shell: bash
-      run: |
-        python3 .github/scripts/unity.py --version ${{ inputs.editor_version }} install --changeset ${{ inputs.editor_changeset }}
-    - name: Run tests (all build targets)
-      if: ${{ inputs.build_target == '' }}
-      shell: bash
-      env:
-        UNITY_EMAIL: ${{ inputs.license_email }}
-        UNITY_PASSWORD: ${{ inputs.license_password }}
-        UNITY_SERIAL: ${{ inputs.license_serial }}
-      run: |
-        python3 .github/scripts/unity.py --version ${{ inputs.editor_version }} test
+        make test
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
@@ -99,4 +76,4 @@ runs:
     - name: Uninstall editor
       shell: bash
       run: |
-        python3 .github/scripts/unity.py --version ${{ inputs.editor_version }} uninstall
+        make uninstall_editor

--- a/.github/scripts/vars.py
+++ b/.github/scripts/vars.py
@@ -8,17 +8,8 @@ import sys
 from os import path
 from typing import Literal, TypedDict
 
+base_path = path.abspath(path.join(path.dirname(__file__), "..", ".."))
 version_re = re.compile(r"m_EditorVersionWithRevision: ([^ ]+) \(([^\)]+)\)")
-
-
-def get_platform() -> Literal["darwin", "linux", "win32"]:
-    """Get a string representing the current platform."""
-    if sys.platform == "darwin":
-        return "darwin"
-    elif sys.platform == "win32":
-        return "win32"
-    else:
-        return "linux"
 
 
 class ProjectEditorVersion(TypedDict):
@@ -27,6 +18,18 @@ class ProjectEditorVersion(TypedDict):
     project: str
     version: str
     changeset: str
+
+
+def get_apple_sdk_version() -> str:
+    filename = path.join(
+        base_path, "io.embrace.sdk", "iOS", "EmbraceUnityiOS", "Package.resolved"
+    )
+    with open(filename, "r") as f:
+        data = json.load(f)
+        for pin in data["pins"]:
+            if pin["identity"] == "embrace-apple-sdk":
+                return pin["state"]["version"]
+    raise ValueError("Unable to find embrace-apple-sdk version")
 
 
 def get_editor_version_with_changeset(project_path: str) -> tuple[str, str]:
@@ -44,7 +47,6 @@ def get_editor_version_with_changeset(project_path: str) -> tuple[str, str]:
 def get_editor_versions(projects: list[str]) -> list[ProjectEditorVersion]:
     """Get the version and changeset of the Unity editor used in a list of projects."""
     results: list[ProjectEditorVersion] = []
-    base_path = path.abspath(path.join(path.dirname(__file__), "..", ".."))
     for project in projects:
         project_path = path.join(base_path, "UnityProjects", project)
         version, changeset = get_editor_version_with_changeset(project_path)
@@ -52,16 +54,61 @@ def get_editor_versions(projects: list[str]) -> list[ProjectEditorVersion]:
     return results
 
 
+def get_platform() -> Literal["darwin", "linux", "win32"]:
+    """Get a string representing the current platform."""
+    if sys.platform == "darwin":
+        return "darwin"
+    elif sys.platform == "win32":
+        return "win32"
+    else:
+        return "linux"
+
+
+def get_sdk_version() -> str:
+    """Get the SDK version to use for the .unitypackage."""
+    with open(path.join(base_path, "io.embrace.sdk", "package.json"), "r") as f:
+        return json.load(f)["version"]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    _apple_sdk_version_parser = subparsers.add_parser("apple-sdk-version")
+
+    editor_versions_parser = subparsers.add_parser("editor-versions")
+    editor_versions_parser.add_argument(
+        "--project",
+        type=str,
+        action="append",
+        help="If specified, override the project to get the version for.",
+    )
+    editor_versions_parser.add_argument(
+        "--field",
+        type=str,
+        choices=["project", "version", "changeset"],
+        default=None,
+        help="If specified, only output this field (as text).",
+    )
+
+    _sdk_version_parser = subparsers.add_parser("sdk-version")
+
     _platform_parser = subparsers.add_parser("platform")
-    _versions_parser = subparsers.add_parser("versions")
+
     args = parser.parse_args(sys.argv[1:])
-    if args.command == "platform":
+    if args.command == "apple-sdk-version":
+        print(get_apple_sdk_version())
+    elif args.command == "editor-versions":
+        versions = get_editor_versions(args.project or ["2021", "2022"])
+        if args.field:
+            field: Literal["project", "version", "changeset"] = args.field
+            print("\n".join(v[field] for v in versions))
+        else:
+            print(json.dumps(versions))
+    elif args.command == "platform":
         print(get_platform())
-    elif args.command == "versions":
-        print(json.dumps(get_editor_versions(["2021", "2022"])))
+    elif args.command == "sdk-version":
+        print(get_sdk_version())
     else:
         raise ValueError(f"Invalid command: {args.command}")
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,7 @@ jobs:
     env:
       # These environment variables are defined by the `make github_env_vars`
       # command below, but are defined here to satisfy the linter.
-      BUILD_METHOD: # C# method to call in the Unity project to build the .unitypackage.
-      BUILD_PROJECT: # Path to the Unity project to build.
-      GAMECI_UNITYPACKAGE: # Path to the file output by game-ci/unity-builder.
-      UNITY_VERSION: # Unity version to use.
+      UNITY_SDK_UNITYPACKAGE: # Path to the .unitypackage file output by the build.
       UNITY_SDK_VERSION: # Embrace Unity SDK version to build.
     steps:
       - name: Checkout repository
@@ -34,31 +31,30 @@ jobs:
         with:
           lfs: true
           ref: ${{ inputs.ref }}
-      - name: Install iOS dependencies
-        run: |
-          make install_ios_dependencies
-      - name: Set build environment variables
+      - name: Get the package version
         run: |
           make github_env_vars | tee -a $GITHUB_ENV
+      - name: Install Unity Hub
+        run: |
+          make install_hub
+      - name: Install editor
+        run: |
+          make install_editor
       - name: Cache Library folder
         uses: actions/cache@v4
         with:
-          path: ${{ env.BUILD_PROJECT }}/Library
-          key: Library-${{ env.UNITY_VERSION }}
+          path: ./UnityProjects/2021/Library
+          key: Library-2021-Android
+          restore-keys: |
+            Library-2021-
+            Library-
       - name: Build .unitypackage
-        uses: game-ci/unity-builder@v4
         env:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-        with:
-          projectPath: ${{ env.BUILD_PROJECT }}
-          unityVersion: ${{ env.UNITY_VERSION }}
-          targetPlatform: Android
-          customImage: "unityci/editor:ubuntu-${{ env.UNITY_VERSION }}-android-3.1.0"
-          customParameters: -buildTarget Android
-          versioning: None
-          buildMethod: ${{ env.BUILD_METHOD }}
+        run: |
+          make build
       - name: Upload package folder artifact
         if: ${{ inputs.package_folder_artifact }}
         uses: actions/upload-artifact@v4
@@ -71,6 +67,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: EmbraceSDK_${{ env.UNITY_SDK_VERSION }}.unitypackage
-          path: ${{ env.GAMECI_UNITYPACKAGE }}
+          path: ${{ env.UNITY_SDK_UNITYPACKAGE }}
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - id: get_editor_versions
         name: Get editor versions
         run: |
-          echo "editor_versions=$(python3 .github/scripts/vars.py versions)" | tee -a "$GITHUB_OUTPUT"
+          echo "editor_versions=$(python3 .github/scripts/vars.py editor-versions)" | tee -a "$GITHUB_OUTPUT"
   test_linux:
     needs: get_editor_versions
     if: ${{ inputs.linux == true }}

--- a/Makefile
+++ b/Makefile
@@ -1,70 +1,55 @@
-UNITY_YEAR ?= 2021
-UNITY_VERSION_2021 ?= 2021.3.37f1
-UNITY_VERSION_2022 ?= 2022.3.56f1
-UNITY_VERSION_2023 ?= 2023.2.20f1
-UNITY_VERSION = $(UNITY_VERSION_$(UNITY_YEAR))
-UNITY_PATH ?= /Applications/Unity/Hub/Editor/$(UNITY_VERSION)/Unity.app/Contents/MacOS/Unity
-BATCH_ARGS ?= -batchmode -logFile - -nographics -timestamps
-BUILD_METHOD = EmbraceSDK.CIPublishTool.ExportUnityPackage
-BUILD_PROJECT := $(or $(BUILD_PROJECT),./UnityProjects/$(UNITY_YEAR))
+PLATFORM = $(shell python3 .github/scripts/vars.py platform)
 
-UNITY_SDK_VERSION = $(shell jq -r '.version' io.embrace.sdk/package.json)
+ifeq ($(strip $(EDITOR_VERSION)),)
+# If the editor version is not set, default to 2021.
+BUILD_TARGET := $(or $(BUILD_TARGET),android)
+EDITOR_VERSION = $(shell python3 .github/scripts/vars.py editor-versions --project 2021 --field version)
+EDITOR_CHANGESET = $(shell python3 .github/scripts/vars.py editor-versions --project 2021 --field changeset)
+endif
+EXTRA_BUILD_ARGS = $(if $(UNITY_SERIAL),, --skip-license)
+EXTRA_INSTALL_ARGS = $(if $(BUILD_TARGET), --module $(BUILD_TARGET),)
+EXTRA_TEST_ARGS = $(if $(BUILD_TARGET), --build-target $(BUILD_TARGET),)$(if $(UNITY_SERIAL),, --skip-license)
+
+UNITY_SDK_VERSION = $(shell python3 .github/scripts/vars.py sdk-version)
 UNITY_SDK_UNITYPACKAGE = build/EmbraceSDK_$(UNITY_SDK_VERSION).unitypackage
 
-APPLE_SDK_VERSION ?= $(shell jq -r '.pins[] | select(.identity == "embrace-apple-sdk") | .state.version' io.embrace.sdk/iOS/EmbraceUnityiOS/Package.resolved)
+APPLE_SDK_VERSION ?= $(shell python3 .github/scripts/vars.py apple-sdk-version)
 APPLE_SDK_DIR = build/embrace_$(APPLE_SDK_VERSION)
 APPLE_SDK_ZIP = build/embrace_$(APPLE_SDK_VERSION).zip
 
-# Run Unity tests.
-# Arguments:
-# $(1) - Unity project year (e.g. 2021)
-# $(2) - Unity version (e.g. 2021.3.37f1)
-# $(3) - build target (e.g. ios)
-# $(4) - test platform (e.g. editmode)
-define run_tests
-	/Applications/Unity/Hub/Editor/$(2)/Unity.app/Contents/MacOS/Unity \
-		$(BATCH_ARGS) \
-		-buildTarget $(3) \
-		-projectPath ./UnityProjects/$(1) \
-		-runTests \
-		-testPlatform $(4) \
-		-testResults $(PWD)/build/test-$(1)-$(3)-$(4)/test-results.xml \
-		-debugCodeOptimization \
-		-enableCodeCoverage \
-		-coverageResultsPath $(PWD)/build/test-$(1)-$(3)-$(4)/coverage-results \
-		-coverageOptions "generateAdditionalMetrics;generateBadgeReport;generateHtmlReport;assemblyFilters:+Embrace,+Embrace.*" \
-		| awk '{ print "[$(1)-$(3)-$(4)] " $$0 }'
-endef
+.PHONY: build clean github_env_vars install_ios_dependencies test test_all version
 
-# Run all tests for a given Unity project year.
-# Arguments:
-# $(1) - Unity project year (e.g. 2021)
-define run_tests_year
-	-$(call run_tests,$(1),$(UNITY_VERSION_$(1)),osxuniversal,editmode)
-	-$(call run_tests,$(1),$(UNITY_VERSION_$(1)),ios,editmode)
-	-$(call run_tests,$(1),$(UNITY_VERSION_$(1)),ios,playmode)
-	-$(call run_tests,$(1),$(UNITY_VERSION_$(1)),android,editmode)
-	-$(call run_tests,$(1),$(UNITY_VERSION_$(1)),android,playmode)
-endef
-
-.PHONY: build clean download_apple_sdk github_env_vars install_ios_dependencies test test_all version
-
+# Build the Unity package for the Embrace Unity SDK.
 build: $(UNITY_SDK_UNITYPACKAGE)
 
+# Remove ephemeral build artifacts.
 clean:
 	-rm -r build
 
-# Print the environment variables, for writing to the GitHub action environment.
+# Print out environment variables needed by the GitHub build action.
 github_env_vars:
-	@echo "APPLE_SDK_VERSION=$(APPLE_SDK_VERSION)"
-	@echo "BUILD_METHOD=$(BUILD_METHOD)"
-	@echo "BUILD_PROJECT=$(BUILD_PROJECT)"
-	@echo "GAMECI_UNITYPACKAGE=$(BUILD_PROJECT)/$(notdir $(UNITY_SDK_UNITYPACKAGE))"
+	@echo "BUILD_TARGET=$(BUILD_TARGET)"
+	@echo "EDITOR_CHANGESET=$(EDITOR_CHANGESET)"
+	@echo "EDITOR_VERSION=$(EDITOR_VERSION)"
+	@echo "UNITY_SDK_UNITYPACKAGE=$(UNITY_SDK_UNITYPACKAGE)"
 	@echo "UNITY_SDK_VERSION=$(UNITY_SDK_VERSION)"
-	@echo "UNITY_VERSION=$(UNITY_VERSION)"
-	@echo "UNITY_VERSION_2021=$(UNITY_VERSION_2021)"
-	@echo "UNITY_VERSION_2022=$(UNITY_VERSION_2022)"
-	@echo "UNITY_VERSION_2023=$(UNITY_VERSION_2023)"
+
+# Install the Unity editor. This is used by the GitHub workflows.
+install_editor:
+	python3 .github/scripts/unity.py --version "$(EDITOR_VERSION)" install --changeset "$(EDITOR_CHANGESET)" $(EXTRA_INSTALL_ARGS)
+
+# Install the Unity Hub, which will be used to install the Unity editor.
+# This is used by the GitHub workflows.
+install_hub:
+ifeq ($(PLATFORM),darwin)
+	brew install --cask unity-hub
+else ifeq ($(PLATFORM),linux)
+	bash .github/scripts/install_hub_linux.sh
+else ifeq ($(PLATFORM),win32)
+	powershell.exe -ExecutionPolicy Bypass -File .github/scripts/install_hub_windows.ps1
+else
+	$(error Platform "$(PLATFORM)" not supported)
+endif
 
 # Install the Embrace Apple SDK dependencies into the Unity project. This is
 # run before building the Unity package.
@@ -74,16 +59,13 @@ install_ios_dependencies: $(APPLE_SDK_DIR)
 	mkdir -p ./io.embrace.sdk/iOS/
 	cp $(APPLE_SDK_DIR)/embrace_symbol_upload.darwin $(APPLE_SDK_DIR)/run.sh ./io.embrace.sdk/iOS/
 
+# Run the Unity tests.
 test:
-	$(call run_tests_year,$(UNITY_YEAR))
+	python3 .github/scripts/unity.py --version "$(EDITOR_VERSION)" test $(EXTRA_TEST_ARGS)
 
-test_all:
-	$(call run_tests_year,2021)
-	$(call run_tests_year,2022)
-	$(call run_tests_year,2023)
-
-version:
-	@echo $(UNITY_SDK_VERSION)
+# Uninstall the Unity editor. This is used by the GitHub workflows.
+uninstall_editor:
+	python3 .github/scripts/unity.py --version "$(EDITOR_VERSION)" uninstall
 
 # Download the Embrace Apple SDK release from GitHub.
 $(APPLE_SDK_ZIP):
@@ -95,9 +77,4 @@ $(APPLE_SDK_DIR): $(APPLE_SDK_ZIP)
 
 # Build the Unity package for the Embrace Unity SDK.
 $(UNITY_SDK_UNITYPACKAGE): install_ios_dependencies
-	$(UNITY_PATH) $(BATCH_ARGS) \
-		-buildTarget android \
-		-projectPath $(BUILD_PROJECT) \
-		-quit \
-		-executeMethod $(BUILD_METHOD)
-	mv -v $(BUILD_PROJECT)/$(notdir $@) $@
+	python3 .github/scripts/unity.py --version $(EDITOR_VERSION) build $(EXTRA_BUILD_ARGS)

--- a/UnityProjects/2022/Assets/Plugins/Android/baseProjectTemplate.gradle
+++ b/UnityProjects/2022/Assets/Plugins/Android/baseProjectTemplate.gradle
@@ -1,6 +1,6 @@
 buildscript {
     dependencies {
-        classpath "io.embrace:embrace-swazzler:6.14.0"
+        classpath "io.embrace:embrace-swazzler:7.1.0"
     }
 }
 


### PR DESCRIPTION
The Makefile and GitHub actions have deviated. This updates the Makefile to match the behavior used by the GitHub actions, and updates the actions to run the Makefile instead of custom logic. This ensures that the behavior of the GitHub actions is (mostly) reproducible by running Makefile commands locally.

This also changes the build workflow to execute directly on the runner instead of using game-ci and Docker.