### PR TITLE
Ben.bennett/native null check

### DIFF
--- a/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
+++ b/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
@@ -174,14 +174,22 @@ namespace EmbraceSDK.Internal
 
         private bool ReadyForCalls()
         {
-            bool result = embraceSharedInstance != null;
-            
-            if (result == true && emb_jniIsAttached() == false && AndroidJNI.AttachCurrentThread() != 0)
+            if (EmbraceSharedInstance == null)
             {
-                result = false;
+                return false;
             }
-            
-            return result;
+
+            if (emb_jniIsAttached() == false)
+            {
+                return false;
+            }
+
+            if (AndroidJNI.AttachCurrentThread() != 0)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         private bool UnityInternalInterfaceReadyForCalls()
@@ -222,21 +230,29 @@ namespace EmbraceSDK.Internal
 
         void IEmbraceProvider.StartSDK(EmbraceStartupArgs args)
         {
-            if (!ReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                return;
+            }
+            
             // enableIntegrationTesting/isDevMode is no longer supported on Android
             // we hard-code to false as this resolves to a functional method call
             // TODO: Update this to the appropriate method call at a later date
             // We need to replace the applicationInstance with the Context
-            EmbraceSharedInstance?.Call(_StartMethod, applicationContext, unityAppFramework);
+            EmbraceSharedInstance.Call(_StartMethod, applicationContext, unityAppFramework);
         }
 
         LastRunEndState IEmbraceProvider.GetLastRunEndState()
         {
-            if (!ReadyForCalls()) { return LastRunEndState.Invalid; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to get last run end state, Embrace SDK not initialized");
+                return LastRunEndState.Invalid;
+            }
 
             try
             {
-                using AndroidJavaObject lastRunStateObject = EmbraceSharedInstance?.Call<AndroidJavaObject>(_GetLastRunEndStateMethod);
+                using AndroidJavaObject lastRunStateObject = EmbraceSharedInstance.Call<AndroidJavaObject>(_GetLastRunEndStateMethod);
                 int lastRunStateInt = lastRunStateObject.Call<int>(_LastRunEndStateGetValueMethod);
 
                 switch (lastRunStateInt)
@@ -260,38 +276,68 @@ namespace EmbraceSDK.Internal
 
         void IEmbraceProvider.SetUserIdentifier(string identifier)
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_SetUserIdentifierMethod, identifier);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to set user identifier, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_SetUserIdentifierMethod, identifier);
         }
 
         void IEmbraceProvider.ClearUserIdentifier()
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_ClearUserIdentifierMethod);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to clear user identifier, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_ClearUserIdentifierMethod);
         }
 
         void IEmbraceProvider.SetUsername(string username)
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_SetUsernameMethod, username);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to set username, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_SetUsernameMethod, username);
         }
 
         void IEmbraceProvider.ClearUsername()
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_ClearUsernameMethod);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to clear username, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_ClearUsernameMethod);
         }
 
         void IEmbraceProvider.SetUserEmail(string email)
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_SetUserEmailMethod, email);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to set user email, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_SetUserEmailMethod, email);
         }
 
         void IEmbraceProvider.ClearUserEmail()
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_ClearUserEmailMethod);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to clear user email, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_ClearUserEmailMethod);
         }
 
         void IEmbraceProvider.SetUserAsPayer()
@@ -306,39 +352,68 @@ namespace EmbraceSDK.Internal
 
         void IEmbraceProvider.AddUserPersona(string persona)
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_AddUserPersonaMethod, persona);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to add user persona, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_AddUserPersonaMethod, persona);
         }
 
         void IEmbraceProvider.ClearUserPersona(string persona)
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_ClearUserPersonaMethod, persona);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to clear user persona, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_ClearUserPersonaMethod, persona);
         }
 
         void IEmbraceProvider.ClearAllUserPersonas()
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_ClearAllUserPersonasMethod);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to clear all user personas, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_ClearAllUserPersonasMethod);
         }
 
         bool IEmbraceProvider.AddSessionProperty(string key, string value, bool permanent)
         {
-            if (!ReadyForCalls()) { return false; }
-            return EmbraceSharedInstance?.Call<bool>(_AddSessionPropertyMethod, key, value, permanent) ?? false;
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to add session property, Embrace SDK not initialized");
+                return false;
+            }
+
+            return EmbraceSharedInstance.Call<bool>(_AddSessionPropertyMethod, key, value, permanent);
         }
 
         void IEmbraceProvider.RemoveSessionProperty(string key)
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call<bool>(_RemoveSessionPropertyMethod, key);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to remove session property, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call<bool>(_RemoveSessionPropertyMethod, key);
         }
 
         Dictionary<string, string> IEmbraceProvider.GetSessionProperties()
         {
-            if (!ReadyForCalls()) { return null; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to get session properties, Embrace SDK not initialized");
+                return null;
+            }
 
-            using AndroidJavaObject javaMap = EmbraceSharedInstance?.Call<AndroidJavaObject>(_GetSessionPropertiesMethod);
+            using AndroidJavaObject javaMap = EmbraceSharedInstance.Call<AndroidJavaObject>(_GetSessionPropertiesMethod);
 
             // The Android SDK can return null if this function is called before the SDK is initialized, or if SDK
             // initialization fails. In this case, return an empty dictionary to match behavior on iOS.
@@ -353,38 +428,48 @@ namespace EmbraceSDK.Internal
 
         void IEmbraceProvider.LogMessage(string message, EMBSeverity severity, Dictionary<string, string> properties)
         {
-            if (!ReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to log message, Embrace SDK not initialized");
+                return;
+            }
+            
             using AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
 
             switch (severity)
             {
                 case EMBSeverity.Warning:
-                    EmbraceSharedInstance?.Call(_LogMessageMethod, message, logWarning, javaMap);
+                    EmbraceSharedInstance.Call(_LogMessageMethod, message, logWarning, javaMap);
                     break;
                 case EMBSeverity.Error:
-                    EmbraceSharedInstance?.Call(_LogMessageMethod, message, logError, javaMap);
+                    EmbraceSharedInstance.Call(_LogMessageMethod, message, logError, javaMap);
                     break;
                 default:
-                    EmbraceSharedInstance?.Call(_LogMessageMethod, message, logInfo, javaMap);
+                    EmbraceSharedInstance.Call(_LogMessageMethod, message, logInfo, javaMap);
                     break;
             }
         }
 
         void IEmbraceProvider.LogMessage(string message, EMBSeverity severity, Dictionary<string, string> properties, sbyte[] attachment)
         {
-            if (!ReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to log message, Embrace SDK not initialized");
+                return;
+            }
+            
             using AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
             
             switch (severity)
             {
                 case EMBSeverity.Warning:
-                    EmbraceSharedInstance?.Call(_LogMessageMethod, message, logWarning, javaMap, attachment);
+                    EmbraceSharedInstance.Call(_LogMessageMethod, message, logWarning, javaMap, attachment);
                     break;
                 case EMBSeverity.Error:
-                    EmbraceSharedInstance?.Call(_LogMessageMethod, message, logError, javaMap, attachment);
+                    EmbraceSharedInstance.Call(_LogMessageMethod, message, logError, javaMap, attachment);
                     break;
                 default:
-                    EmbraceSharedInstance?.Call(_LogMessageMethod, message, logInfo, javaMap, attachment);
+                    EmbraceSharedInstance.Call(_LogMessageMethod, message, logInfo, javaMap, attachment);
                     break;
             }
         }
@@ -392,107 +477,202 @@ namespace EmbraceSDK.Internal
         void IEmbraceProvider.LogMessage(string message, EMBSeverity severity, Dictionary<string, string> properties,
             string attachmentId, string attachmentUrl)
         {
-            if (!ReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to log message, Embrace SDK not initialized");
+                return;
+            }
+            
             using AndroidJavaObject javaMap = DictionaryToJavaMap(properties);
             
             switch (severity)
             {
                 case EMBSeverity.Warning:
-                    EmbraceSharedInstance?.Call(_LogMessageMethod, message, logWarning, javaMap, 
-                        attachmentId, attachmentUrl);
+                    EmbraceSharedInstance.Call(_LogMessageMethod, message, logWarning, javaMap, attachmentId, attachmentUrl);
                     break;
                 case EMBSeverity.Error:
-                    EmbraceSharedInstance?.Call(_LogMessageMethod, message, logError, javaMap, 
-                        attachmentId, attachmentUrl);
+                    EmbraceSharedInstance.Call(_LogMessageMethod, message, logError, javaMap, attachmentId, attachmentUrl);
                     break;
                 default:
-                    EmbraceSharedInstance?.Call(_LogMessageMethod, message, logInfo, javaMap, 
-                        attachmentId, attachmentUrl);
+                    EmbraceSharedInstance.Call(_LogMessageMethod, message, logInfo, javaMap, attachmentId, attachmentUrl);
                     break;
             }
         }
 
         void IEmbraceProvider.AddBreadcrumb(string message)
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_AddBreadcrumbMethod, message);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to add breadcrumb, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_AddBreadcrumbMethod, message);
         }
 
         void IEmbraceProvider.EndSession(bool clearUserInfo)
         {
-            if (!ReadyForCalls()) { return; }
-            EmbraceSharedInstance?.Call(_EndSessionMethod, clearUserInfo);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to end session, Embrace SDK not initialized");
+                return;
+            }
+            
+            EmbraceSharedInstance.Call(_EndSessionMethod, clearUserInfo);
         }
 
         string IEmbraceProvider.GetDeviceId()
         {
-            if (!ReadyForCalls()) { return null; }
-            return EmbraceSharedInstance?.Call<string>(_GetDeviceIdMethod);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to get device id, Embrace SDK not initialized");
+                return null;
+            }
+            
+            return EmbraceSharedInstance.Call<string>(_GetDeviceIdMethod);
         }
 
         bool IEmbraceProvider.StartView(string name)
         {
-            if (!ReadyForCalls()) { return false; }
-            return EmbraceSharedInstance?.Call<bool>(_StartFragmentMethod, name) ?? false;
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to start view, Embrace SDK not initialized");
+                return false;
+            }
+            
+            return EmbraceSharedInstance.Call<bool>(_StartFragmentMethod, name);
         }
 
         bool IEmbraceProvider.EndView(string name)
         {
-            if (!ReadyForCalls()) { return false; }
-            return EmbraceSharedInstance?.Call<bool>(_EndFragmentMethod, name) ?? false;
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to end view, Embrace SDK not initialized");
+                return false;
+            }
+            
+            return EmbraceSharedInstance.Call<bool>(_EndFragmentMethod, name);
         }
 
         void IEmbraceProvider.SetMetaData(string unityVersion, string guid, string sdkVersion)
         {
-            if (!ReadyForCalls()) { return; }
-            if(!UnityInternalInterfaceReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to set meta data, Embrace SDK not initialized");
+                return;
+            }
+
+            if (!UnityInternalInterfaceReadyForCalls())
+            {
+                return;
+            }
+            
             _embraceUnityInternalSharedInstance.Call(_SetUnityMetaDataMethod, unityVersion, guid, sdkVersion);
         }
         
         void IEmbraceProvider.RecordCompletedNetworkRequest(string url, HTTPMethod method, long startms, long endms, long bytesin, long bytesout, int code)
         {
-            if (!ReadyForCalls()) { return; }
-            if(!UnityInternalInterfaceReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to record completed network request, Embrace SDK not initialized");
+                return;
+            }
+
+            if (!UnityInternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to record completed network request, Embrace SDK not initialized");
+                return;
+            }
+            
             _embraceUnityInternalSharedInstance.Call(_RecordCompletedNetworkRequestMethod, url, method.ToString(), startms, endms, bytesout, bytesin, code, null);
         }
         
         void IEmbraceProvider.RecordIncompleteNetworkRequest(string url, HTTPMethod method, long startms, long endms, string error)
         {
-            if (!ReadyForCalls()) { return; }
-            if(!UnityInternalInterfaceReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to record incomplete network request, Embrace SDK not initialized");
+                return;
+            }
+
+            if (!UnityInternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to record incomplete network request, Embrace SDK not initialized");
+                return;
+            }
+            
             _embraceUnityInternalSharedInstance.Call(_RecordIncompleteNetworkRequestMethod, url, method.ToString(), startms, endms, null, error, null);
         }
 
         void IEmbraceProvider.InstallUnityThreadSampler()
         {
-            if (!ReadyForCalls()) { return; }
-            if(!UnityInternalInterfaceReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to install unity thread sampler, Embrace SDK not initialized");
+                return;
+            }
+
+            if (!UnityInternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to install unity thread sampler, Embrace SDK not initialized");
+                return;
+            }
+            
             _embraceUnityInternalSharedInstance.Call(_installUnityThreadSampler);
         }
 
         void IEmbraceProvider.LogUnhandledUnityException(string exceptionName, string exceptionMessage, string stack)
         {
-            if (!ReadyForCalls()) { return; }
-            if(!UnityInternalInterfaceReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to log unhandled unity exception, Embrace SDK not initialized");
+                return;
+            }
+
+            if (!UnityInternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to log unhandled unity exception, Embrace SDK not initialized");
+                return;
+            }
+            
             _embraceUnityInternalSharedInstance.Call(_logUnhandledUnityExceptionMethod, exceptionName, exceptionMessage, stack);
         }
 
         void IEmbraceProvider.LogHandledUnityException(string exceptionName, string exceptionMessage, string stack)
         {
-            if (!ReadyForCalls()) { return; }
-            if(!UnityInternalInterfaceReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to log handled unity exception, Embrace SDK not initialized");
+                return;
+            }
+
+            if (!UnityInternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to log handled unity exception, Embrace SDK not initialized");
+                return;
+            }
+            
             _embraceUnityInternalSharedInstance.Call(_logHandledUnityExceptionMethod, exceptionName, exceptionMessage, stack);
         }
         
         string IEmbraceProvider.GetCurrentSessionId()
         {
-            if (!ReadyForCalls()) { return null; }
-            return EmbraceSharedInstance?.Call<string>(_GetCurrentSessionId);
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to get current session id, Embrace SDK not initialized");
+                return null;
+            }
+            
+            return EmbraceSharedInstance.Call<string>(_GetCurrentSessionId);
         }
 
         void IEmbraceProvider.RecordPushNotification(AndroidPushNotificationArgs androidArgs)
         {
-            if (!ReadyForCalls()) { return; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to record push notification, Embrace SDK not initialized");
+                return;
+            }
 
             using AndroidJavaObject jNotificationPriority =
                 integerClass.CallStatic<AndroidJavaObject>("valueOf", androidArgs.notificationPriority);
@@ -502,14 +682,23 @@ namespace EmbraceSDK.Internal
             using AndroidJavaObject jIsNotification = booleanClass.CallStatic<AndroidJavaObject>("valueOf", androidArgs.isNotification);
             using AndroidJavaObject jHasData = booleanClass.CallStatic<AndroidJavaObject>("valueOf", androidArgs.hasData);
             
-            EmbraceSharedInstance?.Call(_LogPushNotification, androidArgs.title, androidArgs.body, androidArgs.topic, androidArgs.id,
+            EmbraceSharedInstance.Call(_LogPushNotification, androidArgs.title, androidArgs.body, androidArgs.topic, androidArgs.id,
                 jNotificationPriority, jMessageDeliveredPriority, jIsNotification, jHasData);
         }
         
         public string StartSpan(string spanName, string parentSpanId, long startTimeMs)
         {
-            if (!ReadyForCalls()) { return null; }
-            if (!InternalInterfaceReadyForCalls()) { return null; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to start span, Embrace SDK not initialized");
+                return null;
+            }
+
+            if (!InternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to start span, Embrace SDK not initialized");
+                return null;
+            }
             
             var startTime = longClass.CallStatic<AndroidJavaObject>("valueOf", startTimeMs);
             return _embraceUnityInternalSharedInstance.Call<string>(_StartSpanMethod, spanName, parentSpanId, startTime);
@@ -517,8 +706,17 @@ namespace EmbraceSDK.Internal
 
         public bool StopSpan(string spanId, int errorCode, long endTimeMs)
         {
-            if (!ReadyForCalls()) { return false; }
-            if (!InternalInterfaceReadyForCalls()) { return false; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to stop span, Embrace SDK not initialized");
+                return false;
+            }
+
+            if (!InternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to stop span, Embrace SDK not initialized");
+                return false;
+            }
             
             var endTime = longClass.CallStatic<AndroidJavaObject>("valueOf", endTimeMs);
             return _embraceUnityInternalSharedInstance.Call<bool>(_StopSpanMethod, spanId, GetSpanErrorCode(errorCode), endTime); 
@@ -526,16 +724,35 @@ namespace EmbraceSDK.Internal
 
         public bool AddSpanEvent(string spanId, string spanName, long timestampMs, Dictionary<string, string> attributes)
         {
-            if (!ReadyForCalls()) { return false; }
-            if (!InternalInterfaceReadyForCalls()) { return false; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to add span event, Embrace SDK not initialized");
+                return false;
+            }
+
+            if (!InternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to add span event, Embrace SDK not initialized");
+                return false;
+            }
             
             var timestamp = longClass.CallStatic<AndroidJavaObject>("valueOf", timestampMs);
             return _embraceUnityInternalSharedInstance.Call<bool>(_AddSpanEventMethod, spanId, spanName, timestamp, DictionaryToJavaMap(attributes)); }
 
         public bool AddSpanAttribute(string spanId, string key, string value)
         {
-            if (!ReadyForCalls()) { return false; }
-            if (!InternalInterfaceReadyForCalls()) { return false; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to add span attribute, Embrace SDK not initialized");
+                return false;
+            }
+
+            if (!InternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to add span attribute, Embrace SDK not initialized");
+                return false;
+            }
+            
             return _embraceUnityInternalSharedInstance.Call<bool>(_AddSpanAttributeMethod, spanId, key, value); }
         
         /// <summary>
@@ -554,8 +771,17 @@ namespace EmbraceSDK.Internal
         public bool RecordCompletedSpan(string spanName, long startTimeMs, long endTimeMs, int? errorCode, string parentSpanId,
             Dictionary<string, string> attributes, EmbraceSpanEvent[] embraceSpanEvents)
         {
-            if (!ReadyForCalls()) { return false; }
-            if (!InternalInterfaceReadyForCalls()) { return false; }
+            if (!ReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to record completed span, Embrace SDK not initialized");
+                return false;
+            }
+
+            if (!InternalInterfaceReadyForCalls())
+            {
+                EmbraceLogger.Log("Unable to record completed span, Embrace SDK not initialized");
+                return false;
+            }
             
             var spanEvents = new List<Dictionary<string, object>>();
             foreach (var embraceSpanEvent in embraceSpanEvents)
@@ -603,6 +829,7 @@ namespace EmbraceSDK.Internal
                     AndroidJNIHelper.CreateJNIArgArray(new object[] { entry.Key, entry.Value })
                 );
             }
+            
             return map;
         }
         
@@ -613,6 +840,7 @@ namespace EmbraceSDK.Internal
         private static AndroidJavaObject DictionaryWithObjectsToJavaMap(Dictionary<string, object> dictionary, out List<IDisposable> disposables)
         {
             disposables = new List<IDisposable>();
+            
             if (dictionary == null)
             {
                 return null;
@@ -623,12 +851,18 @@ namespace EmbraceSDK.Internal
 
             foreach (var entry in dictionary)
             {
-                if (entry.Key == null) continue;
+                if (entry.Key == null)
+                {
+                    continue;
+                }
 
                 var key = new AndroidJavaObject("java.lang.String", entry.Key);
                 var value = CreateJavaObjectFromNetObject(entry.Value);
 
-                if (value == null) continue;
+                if (value == null)
+                {
+                    continue;
+                }
                             
                 AndroidJNI.CallObjectMethod(
                     map.GetRawObject(),
@@ -640,7 +874,6 @@ namespace EmbraceSDK.Internal
             }
             
             disposables.Add(map);
-
             return map;
         }
         
@@ -651,6 +884,7 @@ namespace EmbraceSDK.Internal
         private static AndroidJavaObject DictionariesToJavaListOfMaps(List<Dictionary<string, object>> dictionaries, out List<IDisposable> disposables)
         {
             disposables = new List<IDisposable>();
+            
             if (dictionaries == null)
             {
                 return null;
@@ -662,6 +896,7 @@ namespace EmbraceSDK.Internal
             foreach (var dictionary in dictionaries)
             {
                 var map = DictionaryWithObjectsToJavaMap(dictionary, out var inner_disposables);
+                
                 if (map != null)
                 {
                     AndroidJNI.CallBooleanMethod(
@@ -669,6 +904,7 @@ namespace EmbraceSDK.Internal
                         listAddMethod,
                         AndroidJNIHelper.CreateJNIArgArray(new object[] { map }));
                 }
+                
                 disposables.AddRange(inner_disposables);
             }
             
@@ -703,10 +939,11 @@ namespace EmbraceSDK.Internal
                 {
                     dict.Add(key, AndroidJNI.CallStringMethod(value, ObjectToString, new jvalue[] { }));
                 }
+                
                 AndroidJNI.DeleteLocalRef(value);
             }
+            
             AndroidJNI.DeleteLocalRef(iterator);
-
             return dict;
         }
 
@@ -749,9 +986,9 @@ namespace EmbraceSDK.Internal
             {
                 return DictionaryToJavaMap(dict);
             }
+            
             // Add more types as needed
             EmbraceLogger.LogError($"Unsupported type: {netObject.GetType()}");
-
             return null;
         }
         

--- a/io.embrace.sdk/Scripts/Native/Embrace_iOS.cs
+++ b/io.embrace.sdk/Scripts/Native/Embrace_iOS.cs
@@ -167,73 +167,162 @@ namespace EmbraceSDK.Internal
             }
         }
 
+        bool IsReadyForCalls()
+        {
+            return embrace_sdk_is_started();
+        }
+
         LastRunEndState IEmbraceProvider.GetLastRunEndState()
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot get last run end state.");
+                return LastRunEndState.Invalid;
+            }
+            
             return (LastRunEndState) embrace_get_last_run_end_state();
         }
 
         void IEmbraceProvider.SetUserIdentifier(string identifier)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot set user identifier.");
+                return;
+            }
+            
             embrace_set_user_identifier(identifier);
         }
 
         void IEmbraceProvider.ClearUserIdentifier()
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot clear user identifier.");
+                return;
+            }
+            
             embrace_clear_user_identifier();
         }
 
         void IEmbraceProvider.SetUsername(string username)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot set username.");
+                return;
+            }
+            
             embrace_set_username(username);
         }
 
         void IEmbraceProvider.ClearUsername()
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot clear username.");
+                return;
+            }
+            
             embrace_clear_username();
         }
 
         void IEmbraceProvider.SetUserEmail(string email)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot set user email.");
+                return;
+            }
+            
             embrace_set_user_email(email);
         }
 
         void IEmbraceProvider.ClearUserEmail()
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot clear user email.");
+                return;
+            }
+            
             embrace_clear_user_email();
         }
 
         void IEmbraceProvider.SetUserAsPayer()
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot set user as payer.");
+                return;
+            }
+            
             embrace_set_user_as_payer();
         }
 
         void IEmbraceProvider.ClearUserAsPayer()
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot clear user as payer.");
+                return;
+            }
+            
             embrace_clear_user_as_payer();
         }
 
         void IEmbraceProvider.AddUserPersona(string persona)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot add user persona.");
+                return;
+            }
+            
             embrace_add_user_persona(persona);
         }
 
         void IEmbraceProvider.ClearUserPersona(string persona)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot clear user persona.");
+                return;
+            }
+            
             embrace_clear_user_persona(persona);
         }
 
         void IEmbraceProvider.ClearAllUserPersonas()
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot clear all user personas.");
+                return;
+            }
+            
             embrace_clear_all_user_personas();
         }
 
         bool IEmbraceProvider.AddSessionProperty(string key, string value, bool permanent)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot add session property.");
+                return false;
+            }
+            
             return embrace_add_session_property(key, value, permanent);
         }
 
         void IEmbraceProvider.RemoveSessionProperty(string key)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot remove session property.");
+                return;
+            }
+            
             embrace_remove_session_property(key);
         }
         
@@ -248,6 +337,12 @@ namespace EmbraceSDK.Internal
 
         void IEmbraceProvider.LogMessage(string message, EMBSeverity severity, Dictionary<string, string> properties)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot log message.");
+                return;
+            }
+            
             if (severity.TryConvertToString(out var severityString))
             {
                 embrace_log_message_with_severity_and_properties(message, severityString, JsonConvert.SerializeObject(properties));    
@@ -256,6 +351,12 @@ namespace EmbraceSDK.Internal
         
         void IEmbraceProvider.LogMessage(string message, EMBSeverity severity, Dictionary<string, string> properties, byte[] attachment)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot log message.");
+                return;
+            }
+            
             if (severity.TryConvertToString(out var severityString))
             {
                 embrace_log_message_with_attachment(message, severityString, JsonConvert.SerializeObject(properties), attachment, attachment.Length);    
@@ -265,6 +366,12 @@ namespace EmbraceSDK.Internal
         void IEmbraceProvider.LogMessage(string message, EMBSeverity severity, Dictionary<string, string> properties,
             string attachmentId, string attachmentUrl)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot log message.");
+                return;
+            }
+            
             if (severity.TryConvertToString(out var severityString))
             {
                 embrace_log_message_with_attachment_url(message, severityString, JsonConvert.SerializeObject(properties), attachmentId, attachmentUrl);
@@ -273,22 +380,46 @@ namespace EmbraceSDK.Internal
 
         void IEmbraceProvider.AddBreadcrumb(string message)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot add breadcrumb.");
+                return;
+            }
+            
             embrace_add_breadcrumb(message);
         }
 
         // iOS doesn't use clearUserInfo
         void IEmbraceProvider.EndSession(bool clearUserInfo)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot end session.");
+                return;
+            }
+            
             embrace_end_session();
         }
 
         string IEmbraceProvider.GetDeviceId()
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot get device ID.");
+                return null;
+            }
+            
             return embrace_get_device_id().ConvertToString();
         }
 
         bool IEmbraceProvider.StartView(string name)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot start view.");
+                return false;
+            }
+            
             var spanId = embrace_start_view(name).ConvertToString();
             if (spanId != null)
             {
@@ -300,6 +431,12 @@ namespace EmbraceSDK.Internal
 
         bool IEmbraceProvider.EndView(string name)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot end view.");
+                return false;
+            }
+            
             if (_viewDictionary.TryGetValue(name, out var spanId))
             {
                 return embrace_end_view(spanId);
@@ -310,18 +447,36 @@ namespace EmbraceSDK.Internal
 
         void IEmbraceProvider.SetMetaData(string unityVersion, string guid, string sdkVersion)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot set metadata.");
+                return;
+            }
+            
             embrace_set_unity_metadata(unityVersion, guid, sdkVersion);
         }
 
         void IEmbraceProvider.RecordCompletedNetworkRequest(string url, HTTPMethod method, long startms, long endms,
             long bytesin, long bytesout, int code)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot record network request.");
+                return;
+            }
+            
             embrace_log_network_request(url, method.ToString(), startms, endms, bytesout, bytesin, code, null);
         }
 
         void IEmbraceProvider.RecordIncompleteNetworkRequest(string url, HTTPMethod method, long startms, long endms,
             string error)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot record incomplete network request.");
+                return;
+            }
+            
             embrace_log_network_request(url, method.ToString(), startms, endms, 0, 0, 0, error);
         }
 
@@ -329,37 +484,74 @@ namespace EmbraceSDK.Internal
         {
             // not supported on iOS yet
             // No-op
+            EmbraceLogger.LogWarning("InstallUnityThreadSampler is not supported on iOS.");
         }
 
         void IEmbraceProvider.RecordPushNotification(iOSPushNotificationArgs iosArgs)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot record push notification.");
+                return;
+            }
+            
             embrace_log_push_notification(iosArgs.title, iosArgs.subtitle, iosArgs.body, iosArgs.badge, iosArgs.category);
         }
 
         void IEmbraceProvider.LogUnhandledUnityException(string exceptionName, string exceptionMessage,
             string stacktrace)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot log unhandled exception.");
+                return;
+            }
+            
             embrace_log_unhandled_exception(exceptionName, exceptionMessage, stacktrace);
         }
 
         void IEmbraceProvider.LogHandledUnityException(string exceptionName, string exceptionMessage, string stacktrace)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot log handled exception.");
+                return;
+            }
+            
             embrace_log_handled_exception(exceptionName, exceptionMessage, stacktrace);
         }
 
         string IEmbraceProvider.GetCurrentSessionId()
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot get current session ID.");
+                return null;
+            }
+            
             return embrace_get_session_id().ConvertToString();
         }
 
         string IEmbraceProvider.StartSpan(string spanName, string parentSpanId, long startTimeMs)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot start span.");
+                return null;
+            }
+            
             var spanId = embrace_start_span(spanName, parentSpanId, startTimeMs).ConvertToString();
             return spanId;
         }
 
         bool IEmbraceProvider.StopSpan(string spanId, int errorCode, long endTimeMs)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot stop span.");
+                return false;
+            }
+            
             embrace_stop_span(spanId, IntToStringErrorCode(errorCode), endTimeMs);
             return false;
         }
@@ -367,11 +559,23 @@ namespace EmbraceSDK.Internal
         bool IEmbraceProvider.AddSpanEvent(string spanName, string spanId, long timestampMs,
             Dictionary<string, string> attributes)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot add span event.");
+                return false;
+            }
+            
             return embrace_add_span_event_to_span(spanId, spanName, timestampMs, JsonConvert.SerializeObject(attributes));
         }
 
         bool IEmbraceProvider.AddSpanAttribute(string spanId, string key, string value)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot add span attribute.");
+                return false;
+            }
+            
             return embrace_add_span_attribute_to_span(spanId, key, value);
         }
 
@@ -379,6 +583,12 @@ namespace EmbraceSDK.Internal
             string parentSpanId,
             Dictionary<string, string> attributes, EmbraceSpanEvent[] events)
         {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError("Embrace SDK is not started. Cannot record completed span.");
+                return false;
+            }
+            
             return embrace_record_completed_span(spanName,
                 startTimeMs, 
                 endTimeMs, 


### PR DESCRIPTION
## Goal

Ensure the SDK is initialized before trying to make calls to it. Logging errors if making calls to the native SDKs before they are ready.

## Testing

Automated tests

## Release Notes

- Code clean up with native SDK handlers in Unity
- Logs for failing calls when the SDKs aren't intialized

**WHAT**:<br>
**WHY**:<br>
**WHO**:Ben Bennett<br>
