### PR TITLE
Ben.bennett/embrace remove monobehavior

### DIFF
--- a/io.embrace.internal/Scripts/ValidationBehavior.cs
+++ b/io.embrace.internal/Scripts/ValidationBehavior.cs
@@ -27,7 +27,7 @@ namespace EmbraceSDK.Internal
         void Awake()
         {
             EmbraceStartupArgs args = new EmbraceStartupArgs(appID);
-            Embrace.Instance.StartSDK(args);
+            Embrace.Start(args);
 
             Embrace.Instance.SetUsername("test_username");
             Embrace.Instance.SetUserEmail("test_email@example.com");

--- a/io.embrace.internal/SmokeTesting/SmokeTests/CrashSmokeTests.cs
+++ b/io.embrace.internal/SmokeTesting/SmokeTests/CrashSmokeTests.cs
@@ -26,7 +26,7 @@ namespace Embrace.Internal.SmokeTests
         [SmokeTest]
         public void LogExceptionThenSdkCrash()
         {
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
             EmbraceSDK.Embrace.Instance.LogUnhandledUnityException("TestException", "Test exception message.", "__test_stack_trace__");
         }
 
@@ -37,7 +37,7 @@ namespace Embrace.Internal.SmokeTests
         [SmokeTest]
         public void LogExceptionThenAbort()
         {
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
             EmbraceSDK.Embrace.Instance.LogUnhandledUnityException("TestException", "Test exception message.", "__test_stack_trace__");
             Utils.ForceCrash(ForcedCrashCategory.Abort);
         }
@@ -49,7 +49,7 @@ namespace Embrace.Internal.SmokeTests
         [SmokeTest]
         public void LogExceptionThenCallPureVirtualFunc()
         {
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
             EmbraceSDK.Embrace.Instance.LogUnhandledUnityException("TestException", "Test exception message.", "__test_stack_trace__");
             Utils.ForceCrash(ForcedCrashCategory.PureVirtualFunction);
         }
@@ -60,7 +60,7 @@ namespace Embrace.Internal.SmokeTests
         public void EndSessionBeforeStart()
         {
             EmbraceSDK.Embrace.Instance.EndSession();
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
         }
         
         // Destroy an Embrace instance before starting it again to confirm that it does not crash.
@@ -70,7 +70,7 @@ namespace Embrace.Internal.SmokeTests
         {
             EmbraceSDK.Embrace.Instance.StartView("TestView");
             Object.DestroyImmediate(EmbraceSDK.Embrace.Instance.listener);
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
         }
 
         // Call every function in the public API to validate that none of them lead to a crash.
@@ -78,7 +78,7 @@ namespace Embrace.Internal.SmokeTests
         [SmokeTest]
         public void ExercisePublicApi()
         {
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
 
             // This won't actually create a new session because we're still within the minimum session length,
             // so this test should still expect 2 session payloads.

--- a/io.embrace.internal/SmokeTesting/SmokeTests/CrashSmokeTests.cs
+++ b/io.embrace.internal/SmokeTesting/SmokeTests/CrashSmokeTests.cs
@@ -69,25 +69,8 @@ namespace Embrace.Internal.SmokeTests
         public void DestroyEmbraceInstanceBeforeStart()
         {
             EmbraceSDK.Embrace.Instance.StartView("TestView");
-            Object.DestroyImmediate(EmbraceSDK.Embrace.Instance);
+            Object.DestroyImmediate(EmbraceSDK.Embrace.Instance.listener);
             EmbraceSDK.Embrace.Instance.StartSDK();
-        }
-
-        // Intentionally inject a bad provider to confirm that the SDK does not crash.
-        // This specific behavior is definitely not how the SDK is intended to be used.
-        [Preserve]
-        [SmokeTest]
-        public IEnumerator InjectBadProvider()
-        {
-            EmbraceSDK.Embrace.Instance.StartSDK();
-            EmbraceSDK.Embrace.Instance.provider = new Embrace_Stub();
-            Object.DestroyImmediate(EmbraceSDK.Embrace.Instance);
-            var embraceRoot = new GameObject();
-            var instance = embraceRoot.AddComponent<EmbraceSDK.Embrace>();
-            Object.DestroyImmediate(embraceRoot);
-            
-            yield return null;
-            instance.StartSDK();
         }
 
         // Call every function in the public API to validate that none of them lead to a crash.

--- a/io.embrace.internal/SmokeTesting/SmokeTests/MiscSmokeTests.cs
+++ b/io.embrace.internal/SmokeTesting/SmokeTests/MiscSmokeTests.cs
@@ -16,9 +16,9 @@ namespace Embrace.Internal.SmokeTests
         [Preserve, SmokeTest]
         public IEnumerator StartSDKTwice()
         {
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
             yield return null;
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
         }
 
         // Open and close the keyboard multiple times to confirm that the native SDK is not logging internal errors
@@ -32,7 +32,7 @@ namespace Embrace.Internal.SmokeTests
             GameObject canvasInstance = GameObject.Instantiate(canvasPrefab);
             InputField inputField = canvasInstance.GetComponentInChildren<InputField>();
 
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
             yield return null;
 
             for (int i = 0; i < iterations; ++i)
@@ -52,7 +52,7 @@ namespace Embrace.Internal.SmokeTests
         [Preserve, SmokeTest]
         public void LogErrorImmediatelyAfterStart()
         {
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
             EmbraceSDK.Embrace.Instance.LogMessage("Error message", EMBSeverity.Error);
         }
 
@@ -62,7 +62,7 @@ namespace Embrace.Internal.SmokeTests
         [Preserve, SmokeTest]
         public IEnumerator LogErrorOneSecondAfterStart()
         {
-            EmbraceSDK.Embrace.Instance.StartSDK();
+            EmbraceSDK.Embrace.Start();
             yield return new WaitForSeconds(1f);
             EmbraceSDK.Embrace.Instance.LogMessage("Error message", EMBSeverity.Error);
         }

--- a/io.embrace.internal/SmokeTesting/SmokeTests/NeutralStartup.cs
+++ b/io.embrace.internal/SmokeTesting/SmokeTests/NeutralStartup.cs
@@ -18,7 +18,7 @@ namespace Embrace.Internal.SmokeTests
             [Preserve, SmokeTest]
             public void StartSDKForReport()
             {
-                EmbraceSDK.Embrace.Instance.StartSDK();
+                EmbraceSDK.Embrace.Start();
             }
         }
     }

--- a/io.embrace.internal/Testing/Edit Mode Tests/AutomaticNetworkCaptureTests.cs
+++ b/io.embrace.internal/Testing/Edit Mode Tests/AutomaticNetworkCaptureTests.cs
@@ -53,9 +53,20 @@ namespace EmbraceSDK.Tests
                 _hasRecompiled = true;
             }
 
-            _embraceInstance = Embrace.Create();
-            _embraceInstance.provider = Substitute.For<IEmbraceProvider>();
-            _embraceInstance.StartSDK();
+            _embraceInstance = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
+            _embraceInstance.StartSDK(null, false);
+        }
+
+        [UnityTearDown]
+        public IEnumerator TearDown()
+        {
+            _embraceInstance.provider.ClearReceivedCalls();
+            _embraceInstance.StopSDK();
+            yield return null;
         }
 
         #region UnityWebRequest
@@ -639,8 +650,10 @@ namespace EmbraceSDK.Tests
         [UnityTest]
         public IEnumerator UnityWebRequest_NotLoggedIfSDKHasNotStarted()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             using (UnityWebRequest request = UnityWebRequest.Get(GET_URL))
             {

--- a/io.embrace.internal/Testing/Edit Mode Tests/EmbraceExceptionLoggerTests.cs
+++ b/io.embrace.internal/Testing/Edit Mode Tests/EmbraceExceptionLoggerTests.cs
@@ -48,7 +48,7 @@ namespace EmbraceSDK.Tests
             const string message = "__Test threaded log message__";
 
             Embrace mockEmbrace = Substitute.For<Embrace>();
-            Embrace.Create().StartSDK();
+            mockEmbrace.StartSDK(null, false);
 
             Thread thread = new Thread(() => { Debug.Log(message); });
             thread.Start();

--- a/io.embrace.internal/Testing/Edit Mode Tests/EmbraceTests.cs
+++ b/io.embrace.internal/Testing/Edit Mode Tests/EmbraceTests.cs
@@ -1,16 +1,9 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using System.Threading;
-using EmbraceSDK;
 using EmbraceSDK.Internal;
 using EmbraceSDK.Utilities;
 using NSubstitute;
-using NSubstitute.ReceivedExtensions;
 using NUnit.Framework;
-using UnityEditor;
-using UnityEditor.Build;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -25,6 +18,7 @@ namespace EmbraceSDK.Tests
         public void EmbraceCreate()
         {
             Embrace embrace = new Embrace();
+            embrace.StartSDK(null, false);
             Assert.IsInstanceOf<Embrace>(embrace);
         }
 
@@ -290,6 +284,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Error;
             Dictionary<string, string> properties = new Dictionary<string, string>();
@@ -305,6 +300,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Error;
             embrace.LogMessage(message, severity);
@@ -319,6 +315,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             EMBSeverity severity = EMBSeverity.Error;
             Embrace.Instance.LogMessage(null, severity);
             LogAssert.Expect(LogType.Error, "[Embrace Unity SDK] : null log message is not allowed through the Embrace SDK.");
@@ -332,6 +329,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Info;
 #if UNITY_IOS || UNITY_TVOS

--- a/io.embrace.internal/Testing/Edit Mode Tests/EmbraceTests.cs
+++ b/io.embrace.internal/Testing/Edit Mode Tests/EmbraceTests.cs
@@ -108,6 +108,7 @@ namespace EmbraceSDK.Tests
             {
                 provider = Substitute.For<IEmbraceProvider>()
             };
+            embrace.StartSDK(null, false);
             string identifier = "TestIdentifier";
             embrace.SetUserIdentifier(identifier);
             embrace.provider.Received().SetUserIdentifier(identifier);
@@ -121,6 +122,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.ClearUserIdentifier();
             embrace.provider.Received().ClearUserIdentifier();
         }
@@ -133,6 +135,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.SetUsername("test name");
             embrace.provider.Received().SetUsername("test name");
         }
@@ -145,6 +148,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.ClearUsername();
             embrace.provider.Received().ClearUsername();
         }
@@ -157,6 +161,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string email = "test@email.com";
             embrace.SetUserEmail(email);
             embrace.provider.Received().SetUserEmail(email);
@@ -170,6 +175,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.ClearUserEmail();
             embrace.provider.Received().ClearUserEmail();
         }
@@ -182,6 +188,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.SetUserAsPayer();
             embrace.provider.Received().SetUserAsPayer();
         }
@@ -194,6 +201,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.ClearUserAsPayer();
             embrace.provider.Received().ClearUserAsPayer();
         }
@@ -206,6 +214,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string persona = "Test Persona";
             embrace.AddUserPersona(persona);
             embrace.provider.Received().AddUserPersona(persona);
@@ -219,6 +228,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string persona = "Test Persona";
             embrace.ClearUserPersona(persona);
             embrace.provider.Received().ClearUserPersona(persona);
@@ -232,6 +242,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.ClearAllUserPersonas();
             embrace.provider.Received().ClearAllUserPersonas();
         }
@@ -244,6 +255,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string key = "testKey";
             string value = "testValue";
             bool permanent = true;
@@ -259,6 +271,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string key = "testKey";
             embrace.RemoveSessionProperty(key);
             embrace.provider.Received().RemoveSessionProperty(key);
@@ -272,6 +285,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.GetSessionProperties();
             embrace.provider.Received().GetSessionProperties();
         }
@@ -317,7 +331,7 @@ namespace EmbraceSDK.Tests
             
             embrace.StartSDK(null, false);
             EMBSeverity severity = EMBSeverity.Error;
-            Embrace.Instance.LogMessage(null, severity);
+            embrace.LogMessage(null, severity);
             LogAssert.Expect(LogType.Error, "[Embrace Unity SDK] : null log message is not allowed through the Embrace SDK.");
         }
 
@@ -334,7 +348,7 @@ namespace EmbraceSDK.Tests
             EMBSeverity severity = EMBSeverity.Info;
 #if UNITY_IOS || UNITY_TVOS
             byte[] attachment = new byte[1024 * 1024]; // > 1 MiB
-            Embrace.Instance.LogMessage(message, severity, null, attachment);
+            embrace.LogMessage(message, severity, null, attachment);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Info, Arg.Any<Dictionary<string, string>>(), attachment);
 #elif UNITY_ANDROID
             sbyte[] attachment = new sbyte[1024 * 1024]; // > 1 MiB
@@ -350,12 +364,13 @@ namespace EmbraceSDK.Tests
             {
                 provider = Substitute.For<IEmbraceProvider>()
             };
+            embrace.StartSDK(null, false);
             
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Info;
 #if UNITY_IOS || UNITY_TVOS
             byte[] attachment = new byte[1024 * 1025]; // > 1 MiB
-            Embrace.Instance.LogMessage(message, severity, null, attachment);
+            embrace.LogMessage(message, severity, null, attachment);
             embrace.provider.Received().AddBreadcrumb($"Embrace Attachment failure. Attachment size too large. Message: {message}");
 #elif UNITY_ANDROID
             sbyte[] attachment = new sbyte[1024 * 1025]; // > 1 MiB
@@ -372,6 +387,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Info;
             string attachmentId = new Guid().ToString();
@@ -388,6 +404,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string message = "test message";
             embrace.LogInfo(message);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Info, Arg.Any<Dictionary<string, string>>());
@@ -401,6 +418,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string message = "test message";
             embrace.LogWarning(message);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Warning, Arg.Any<Dictionary<string, string>>());
@@ -415,6 +433,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string message = "test message";
             embrace.LogError(message);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Error, Arg.Any<Dictionary<string, string>>());
@@ -429,6 +448,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             string message = "test message";
             embrace.AddBreadcrumb(message);
             embrace.provider.Received().AddBreadcrumb(message);
@@ -442,6 +462,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.EndSession();
             embrace.provider.Received().EndSession(false);
         }
@@ -454,6 +475,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.GetDeviceId();
             embrace.provider.Received().GetDeviceId();
         }
@@ -466,6 +488,7 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
 
+            embrace.StartSDK(null, false);
             embrace.GetCurrentSessionId();
             embrace.provider.Received().GetCurrentSessionId();
         }
@@ -483,6 +506,7 @@ namespace EmbraceSDK.Tests
         public void GetCurrentSessionId_IsNotNull_IfSDKNotStarted_Test()
         {
             Embrace embrace = new Embrace();
+            embrace.StartSDK(null, false);
             var sessionId = Embrace.Instance.GetCurrentSessionId();
             Assert.NotNull(sessionId);
             Assert.IsEmpty(sessionId);
@@ -495,6 +519,7 @@ namespace EmbraceSDK.Tests
             {
                 provider = Substitute.For<IEmbraceProvider>()
             };
+            embrace.StartSDK(null, false);
             
             string message = "test message";
             embrace.StartView(message);
@@ -508,6 +533,7 @@ namespace EmbraceSDK.Tests
             {
                 provider = Substitute.For<IEmbraceProvider>()
             };
+            embrace.StartSDK(null, false);
             
             string name = "test name";
             embrace.EndView(name);
@@ -521,6 +547,7 @@ namespace EmbraceSDK.Tests
             {
                 provider = Substitute.For<IEmbraceProvider>()
             };
+            embrace.StartSDK(null, false);
             
             string url = "url";
             HTTPMethod method = HTTPMethod.GET;
@@ -541,13 +568,14 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
             HTTPMethod method = HTTPMethod.GET;
             long startms = 1;
             long endms = 3;
             int bytesSent = 100;
             int bytesReceived = 150;
             int code = 200;
-            Embrace.Instance.RecordCompleteNetworkRequest(null, method, startms, endms, bytesReceived, bytesSent, code);
+            embrace.RecordCompleteNetworkRequest(null, method, startms, endms, bytesReceived, bytesSent, code);
             LogAssert.Expect(LogType.Error, $"[Embrace Unity SDK] : null network url is not allowed through the Embrace SDK.");
         }
 
@@ -558,6 +586,7 @@ namespace EmbraceSDK.Tests
             {
                 provider = Substitute.For<IEmbraceProvider>()
             };
+            embrace.StartSDK(null, false);
             
             string url = "url";
             HTTPMethod method = HTTPMethod.GET;
@@ -581,7 +610,7 @@ namespace EmbraceSDK.Tests
             long startms = 1;
             long endms = 2;
             string error = "error";
-            Embrace.Instance.RecordIncompleteNetworkRequest(null, method, startms, endms, error);
+            embrace.RecordIncompleteNetworkRequest(null, method, startms, endms, error);
             LogAssert.Expect(LogType.Error, $"[Embrace Unity SDK] : null network url is not allowed through the Embrace SDK.");
         }
         
@@ -597,7 +626,7 @@ namespace EmbraceSDK.Tests
             HTTPMethod method = HTTPMethod.GET;
             long startms = 1;
             long endms = 2;
-            Embrace.Instance.RecordIncompleteNetworkRequest(url, method, startms, endms, null);
+            embrace.RecordIncompleteNetworkRequest(url, method, startms, endms, null);
             LogAssert.Expect(LogType.Error, $"[Embrace Unity SDK] : null network error is not allowed through the Embrace SDK.");
         }
 
@@ -608,10 +637,12 @@ namespace EmbraceSDK.Tests
                 provider = Substitute.For<IEmbraceProvider>()
             };
             
+            embrace.StartSDK(null, false);
+            
 #if UNITY_IOS
             var iosArgs = new iOSPushNotificationArgs("title", "body", 
                 "subtitle", "category", 0);
-            Embrace.Instance.RecordPushNotification(iosArgs);
+            embrace.RecordPushNotification(iosArgs);
             embrace.provider.Received().RecordPushNotification(iosArgs);
 #elif UNITY_ANDROID
             var androidArgs = new AndroidPushNotificationArgs("title", "body", "topic", 

--- a/io.embrace.internal/Testing/Edit Mode Tests/EmbraceTests.cs
+++ b/io.embrace.internal/Testing/Edit Mode Tests/EmbraceTests.cs
@@ -24,34 +24,16 @@ namespace EmbraceSDK.Tests
         [Test]
         public void EmbraceCreate()
         {
-            Embrace embrace = Embrace.Create();
-
+            Embrace embrace = new Embrace();
             Assert.IsInstanceOf<Embrace>(embrace);
-        }
-
-        [Test]
-        [Order(0)]
-        public void GetExistingInstance_DoesNotInstantiate()
-        {
-            if (Embrace.Instance != null)
-            {
-                UnityEngine.Object.DestroyImmediate(Embrace.Instance);
-            }
-            // We need to use IsTrue instead of IsNull because Embrace is a Unity object which overrides the == operator
-            // for in-editor fake null shenanigans.
-            Assert.IsTrue(InternalEmbrace.GetExistingInstance() == null);
-            var instance = Embrace.Create();
-            Assert.IsNotNull(instance);
-            Assert.AreEqual(instance, InternalEmbrace.GetExistingInstance());
         }
 
         [Test]
         public void EmbraceIsStarted()
         {
-            Embrace embrace = Embrace.Create();
-
+            Embrace embrace = new Embrace();
             Assert.IsFalse(embrace.IsStarted);
-            embrace.StartSDK();
+            embrace.StartSDK(null, false);
             Assert.IsTrue(embrace.IsStarted);
         }
 
@@ -62,22 +44,26 @@ namespace EmbraceSDK.Tests
         [Test]
         public void StartSDKProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             TextAsset targetFile = Resources.Load<TextAsset>("Info/EmbraceSdkInfo");
             EmbraceSdkInfo sdkInfo = JsonUtility.FromJson<EmbraceSdkInfo>(targetFile.text);
-
-            embrace.StartSDK();
-
-            embrace.provider.Received().StartSDK(null);
+            embrace.StartSDK(null, false);
+            embrace.provider.Received().StartSDK();
             embrace.provider.Received().SetMetaData(Application.unityVersion, Application.buildGUID, sdkInfo.version);
         }
 
         [Test]
         public void StartSDKiOSTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             TextAsset targetFile = Resources.Load<TextAsset>("Info/EmbraceSdkInfo");
             EmbraceSdkInfo sdkInfo = JsonUtility.FromJson<EmbraceSdkInfo>(targetFile.text);
 
@@ -88,21 +74,22 @@ namespace EmbraceSDK.Tests
                 "devBaseUrl",
                 "configBaseUrl");
             
-            embrace.StartSDK(startupArgs);
+            embrace.StartSDK(startupArgs, false);
             embrace.provider.Received().StartSDK(startupArgs);
         }
 
         [Test]
         public void StartSDKWithIntegrationTestingProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             TextAsset targetFile = Resources.Load<TextAsset>("Info/EmbraceSdkInfo");
             EmbraceSdkInfo sdkInfo = JsonUtility.FromJson<EmbraceSdkInfo>(targetFile.text);
             EmbraceStartupArgs args = new EmbraceStartupArgs();
-            
-            embrace.StartSDK(args);
-
+            embrace.StartSDK(args, false);
             embrace.provider.Received().StartSDK(args);
             embrace.provider.Received().SetMetaData(Application.unityVersion, Application.buildGUID, sdkInfo.version);
         }
@@ -110,232 +97,250 @@ namespace EmbraceSDK.Tests
         [Test]
         public void StartSDKMultipleTimesTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            embrace.StartSDK();
-            embrace.StartSDK();
-
-            embrace.provider.Received(1).StartSDK(null);
+            embrace.StartSDK(null, false);
+            embrace.StartSDK(null, false);
+            embrace.provider.Received(1).StartSDK();
         }
 
         [Test]
         public void SetUserIdentifierProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
             string identifier = "TestIdentifier";
-
-            Embrace.Instance.SetUserIdentifier(identifier);
-
+            embrace.SetUserIdentifier(identifier);
             embrace.provider.Received().SetUserIdentifier(identifier);
         }
 
         [Test]
         public void ClearUserIdentifierProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.ClearUserIdentifier();
-
+            embrace.ClearUserIdentifier();
             embrace.provider.Received().ClearUserIdentifier();
         }
 
         [Test]
         public void SetUsernameProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.SetUsername("test name");
-
+            embrace.SetUsername("test name");
             embrace.provider.Received().SetUsername("test name");
         }
 
         [Test]
         public void ClearUsernameProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.ClearUsername();
-
+            embrace.ClearUsername();
             embrace.provider.Received().ClearUsername();
         }
 
         [Test]
         public void SetUserEmailProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string email = "test@email.com";
-
-            Embrace.Instance.SetUserEmail(email);
-
+            embrace.SetUserEmail(email);
             embrace.provider.Received().SetUserEmail(email);
         }
 
         [Test]
         public void ClearUserEmailProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.ClearUserEmail();
-
+            embrace.ClearUserEmail();
             embrace.provider.Received().ClearUserEmail();
         }
 
         [Test]
         public void SetUserAsPayerProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.SetUserAsPayer();
-
+            embrace.SetUserAsPayer();
             embrace.provider.Received().SetUserAsPayer();
         }
 
         [Test]
         public void ClearUserAsPayerProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.ClearUserAsPayer();
-
+            embrace.ClearUserAsPayer();
             embrace.provider.Received().ClearUserAsPayer();
         }
 
         [Test]
         public void AddUserPersonaProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string persona = "Test Persona";
-
-            Embrace.Instance.AddUserPersona(persona);
-
+            embrace.AddUserPersona(persona);
             embrace.provider.Received().AddUserPersona(persona);
         }
 
         [Test]
         public void ClearUserPersonaProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string persona = "Test Persona";
-
-            Embrace.Instance.ClearUserPersona(persona);
-
+            embrace.ClearUserPersona(persona);
             embrace.provider.Received().ClearUserPersona(persona);
         }
 
         [Test]
         public void ClearAllUserPersonasProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.ClearAllUserPersonas();
-
+            embrace.ClearAllUserPersonas();
             embrace.provider.Received().ClearAllUserPersonas();
         }
 
         [Test]
         public void AddSessionPropertyProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string key = "testKey";
             string value = "testValue";
             bool permanent = true;
-
-            Embrace.Instance.AddSessionProperty(key, value, permanent);
-
+            embrace.AddSessionProperty(key, value, permanent);
             embrace.provider.Received().AddSessionProperty(key, value, permanent);
         }
 
         [Test]
         public void RemoveSessionPropertyProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string key = "testKey";
-
-            Embrace.Instance.RemoveSessionProperty(key);
-
+            embrace.RemoveSessionProperty(key);
             embrace.provider.Received().RemoveSessionProperty(key);
         }
 
         [Test]
         public void GetSessionPropertiesProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.GetSessionProperties();
-
+            embrace.GetSessionProperties();
             embrace.provider.Received().GetSessionProperties();
         }
         
         [Test]
         public void LogMessage_WithArgs_ProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Error;
             Dictionary<string, string> properties = new Dictionary<string, string>();
-
-            Embrace.Instance.LogMessage(message, severity, properties);
-
+            embrace.LogMessage(message, severity, properties);
             embrace.provider.Received().LogMessage(message, severity, Arg.Is<Dictionary<string, string>>(d => d.Count == 0));
         }
 
         [Test]
         public void LogMessageProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Error;
-
-            Embrace.Instance.LogMessage(message, severity);
-
+            embrace.LogMessage(message, severity);
             embrace.provider.Received().LogMessage(message, severity, Arg.Is<Dictionary<string, string>>(d => d.Count == 0));
         }
         
         [Test]
         public void LogMessage_Returns_WhenMessageIsNull_Test()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             EMBSeverity severity = EMBSeverity.Error;
-
             Embrace.Instance.LogMessage(null, severity);
-
             LogAssert.Expect(LogType.Error, "[Embrace Unity SDK] : null log message is not allowed through the Embrace SDK.");
         }
 
         [Test]
         public void LogMessage_With_Attachment()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Info;
 #if UNITY_IOS || UNITY_TVOS
             byte[] attachment = new byte[1024 * 1024]; // > 1 MiB
-            
             Embrace.Instance.LogMessage(message, severity, null, attachment);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Info, Arg.Any<Dictionary<string, string>>(), attachment);
 #elif UNITY_ANDROID
             sbyte[] attachment = new sbyte[1024 * 1024]; // > 1 MiB
-            
-            Embrace.Instance.LogMessage(message, severity, null, attachment);
+            embrace.LogMessage(message, severity, null, attachment);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Info, Arg.Any<Dictionary<string, string>>(), attachment);
 #endif
         }
@@ -343,56 +348,63 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogMessage_With_Attachment_Rejects_Large_Size()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Info;
-            #if UNITY_IOS || UNITY_TVOS
+#if UNITY_IOS || UNITY_TVOS
             byte[] attachment = new byte[1024 * 1025]; // > 1 MiB
-            
             Embrace.Instance.LogMessage(message, severity, null, attachment);
             embrace.provider.Received().AddBreadcrumb($"Embrace Attachment failure. Attachment size too large. Message: {message}");
-            #elif UNITY_ANDROID
+#elif UNITY_ANDROID
             sbyte[] attachment = new sbyte[1024 * 1025]; // > 1 MiB
-            
-            Embrace.Instance.LogMessage(message, severity, null, attachment);
+            embrace.LogMessage(message, severity, null, attachment);
             embrace.provider.Received().AddBreadcrumb($"Embrace Attachment failure. Attachment size too large. Message: {message}");
-            #endif
+#endif
         }
 
         [Test]
         public void LogMessageWithAttachmentUrl()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
             EMBSeverity severity = EMBSeverity.Info;
             string attachmentId = new Guid().ToString();
             string attachmentUrl = "http://www.example.com";
-            
-            Embrace.Instance.LogMessage(message, severity, null, attachmentId, attachmentUrl);
+            embrace.LogMessage(message, severity, null, attachmentId, attachmentUrl);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Info, Arg.Any<Dictionary<string, string>>(), attachmentId, attachmentUrl);
         }
 
         [Test]
         public void LogInfoProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
-
-            Embrace.Instance.LogInfo(message);
+            embrace.LogInfo(message);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Info, Arg.Any<Dictionary<string, string>>());
         }
 
         [Test]
         public void LogWarningProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
-
-            Embrace.Instance.LogWarning(message);
+            embrace.LogWarning(message);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Warning, Arg.Any<Dictionary<string, string>>());
 
         }
@@ -400,11 +412,13 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogErrorProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
-
-            Embrace.Instance.LogError(message);
+            embrace.LogError(message);
             embrace.provider.Received().LogMessage(message, EMBSeverity.Error, Arg.Any<Dictionary<string, string>>());
 
         }
@@ -412,66 +426,66 @@ namespace EmbraceSDK.Tests
         [Test]
         public void AddBreadcrumbProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
-
-            Embrace.Instance.AddBreadcrumb(message);
-
+            embrace.AddBreadcrumb(message);
             embrace.provider.Received().AddBreadcrumb(message);
         }
 
         [Test]
         public void EndSessionProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.EndSession();
-
+            embrace.EndSession();
             embrace.provider.Received().EndSession(false);
         }
 
         [Test]
         public void GetDeviceIdProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.GetDeviceId();
-
+            embrace.GetDeviceId();
             embrace.provider.Received().GetDeviceId();
         }
         
         [Test]
         public void GetCurrentSessionIdProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            Embrace.Instance.GetCurrentSessionId();
-
+            embrace.GetCurrentSessionId();
             embrace.provider.Received().GetCurrentSessionId();
         }
         
         [Test]
         public void GetCurrentSessionId_IsNotNull_IfSDKStarted_Test()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.StartSDK();
-            
+            Embrace embrace = new Embrace();
+            embrace.StartSDK(null, false);
             var sessionId = Embrace.Instance.GetCurrentSessionId();
-            
             Assert.NotNull(sessionId);
         }
         
         [Test]
         public void GetCurrentSessionId_IsNotNull_IfSDKNotStarted_Test()
         {
-            Embrace embrace = Embrace.Create();
-            
+            Embrace embrace = new Embrace();
             var sessionId = Embrace.Instance.GetCurrentSessionId();
-            
             Assert.NotNull(sessionId);
             Assert.IsEmpty(sessionId);
         }
@@ -479,32 +493,37 @@ namespace EmbraceSDK.Tests
         [Test]
         public void StartViewProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string message = "test message";
-
-            Embrace.Instance.StartView(message);
-
+            embrace.StartView(message);
             embrace.provider.Received().StartView(message);
         }
 
         [Test]
         public void EndViewProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string name = "test name";
-
-            Embrace.Instance.EndView(name);
-
+            embrace.EndView(name);
             embrace.provider.Received().EndView(name);
         }
         
         [Test]
         public void RecordCompletedNetworkRequestTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string url = "url";
             HTTPMethod method = HTTPMethod.GET;
             long startms = 1;
@@ -512,15 +531,18 @@ namespace EmbraceSDK.Tests
             int bytesSent = 100;
             int bytesReceived = 150;
             int code = 200;
-            Embrace.Instance.RecordCompleteNetworkRequest(url, method, startms, endms, bytesReceived, bytesSent, code);
+            embrace.RecordCompleteNetworkRequest(url, method, startms, endms, bytesReceived, bytesSent, code);
             embrace.provider.Received().RecordCompletedNetworkRequest(url, method, startms, endms, bytesReceived, bytesSent, code);
         }
         
         [Test]
         public void RecordCompletedNetworkRequest_Return_WhenUrlIsNull_Test()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             HTTPMethod method = HTTPMethod.GET;
             long startms = 1;
             long endms = 3;
@@ -534,14 +556,17 @@ namespace EmbraceSDK.Tests
         [Test]
         public void RecordIncompleteNetworkRequestTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string url = "url";
             HTTPMethod method = HTTPMethod.GET;
             long startms = 1;
             long endms = 2;
             string error = "error";
-            Embrace.Instance.RecordIncompleteNetworkRequest(url, method, startms, endms, error);
+            embrace.RecordIncompleteNetworkRequest(url, method, startms, endms, error);
             embrace.provider.Received().RecordIncompleteNetworkRequest(url, method, startms, endms, error);
         }
         
@@ -549,8 +574,11 @@ namespace EmbraceSDK.Tests
         [Test]
         public void RecordIncompleteNetworkRequestTest_Return_WhenUrlIsNull_Test()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             HTTPMethod method = HTTPMethod.GET;
             long startms = 1;
             long endms = 2;
@@ -562,8 +590,11 @@ namespace EmbraceSDK.Tests
         [Test]
         public void RecordIncompleteNetworkRequestTest_Return_WhenErrorIsNull_Test()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             string url = "url";
             HTTPMethod method = HTTPMethod.GET;
             long startms = 1;
@@ -574,83 +605,84 @@ namespace EmbraceSDK.Tests
 
         public void RecordPushNotificationProviderTest()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
             
-            #if UNITY_IOS
-            
+#if UNITY_IOS
             var iosArgs = new iOSPushNotificationArgs("title", "body", 
                 "subtitle", "category", 0);
             Embrace.Instance.RecordPushNotification(iosArgs);
             embrace.provider.Received().RecordPushNotification(iosArgs);
-            
-            #elif UNITY_ANDROID
-            
+#elif UNITY_ANDROID
             var androidArgs = new AndroidPushNotificationArgs("title", "body", "topic", 
                 "id", 0, 0, false, false);
             Embrace.Instance.RecordPushNotification(androidArgs);
             embrace.provider.Received().RecordPushNotification(androidArgs);
-            
-            #endif
+#endif
         }
 
         [Test]
         public void LogUnhandledUnityExceptionProviderTest_WithStringParams()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             const string exceptionName = "Exception";
             const string exceptionMessage = "exception Message";
             string stack = Environment.StackTrace;
-
-            Embrace.Instance.LogUnhandledUnityException(exceptionName, exceptionMessage, stack);
-
+            embrace.LogUnhandledUnityException(exceptionName, exceptionMessage, stack);
             embrace.provider.Received(1).LogUnhandledUnityException(exceptionName, exceptionMessage, stack);
         }
 
         [Test]
         public void LogUnhandledUnityExceptionProviderTest_WithExceptionInstance()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             const string exceptionMessage = "exception Message";
             Exception exception = new Exception(exceptionMessage);
             string stack = Environment.StackTrace;
-
-            Embrace.Instance.LogUnhandledUnityException(exception, stack);
-
+            embrace.LogUnhandledUnityException(exception, stack);
             embrace.provider.Received(1).LogUnhandledUnityException("Exception", exceptionMessage, stack);
         }
 
         [Test]
         public void LogHandledUnityExceptionProviderTest_WithStringParams()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             const string exceptionName = "Exception";
             const string exceptionMessage = "exception Message";
             string stack = Environment.StackTrace;
-
-            Embrace.Instance.LogHandledUnityException(exceptionName, exceptionMessage, stack);
-
+            embrace.LogHandledUnityException(exceptionName, exceptionMessage, stack);
             embrace.provider.Received(1).LogHandledUnityException(exceptionName, exceptionMessage, stack);
         }
 
         [Test]
         public void LogHandledUnityExceptionProviderTest_WithExceptionInstance()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
             const string exceptionMessage = "exception Message";
             Exception exception = new Exception(exceptionMessage);
             string stack = Environment.StackTrace;
-
-            Embrace.Instance.LogHandledUnityException(exception, stack);
-
+            embrace.LogHandledUnityException(exception, stack);
             embrace.provider.Received(1).LogHandledUnityException("Exception", exceptionMessage, stack);
         }
-
-
+        
         #endregion
 
         /// <summary>
@@ -661,8 +693,7 @@ namespace EmbraceSDK.Tests
         public void NoNullsError()
         {
             LogAssert.Expect(LogType.Error, "[Embrace Unity SDK] : null username is not allowed through the Embrace SDK.");
-
-            Embrace embrace = Embrace.Create();
+            Embrace embrace = new Embrace();
             embrace.SetUsername(null);
         }
 
@@ -671,13 +702,10 @@ namespace EmbraceSDK.Tests
         {
             UnhandledExceptionRateLimiting rateLimiter = new UnhandledExceptionRateLimiting();
             UnhandledException ue = new UnhandledException("Test", "stackTrace test");
-
             TimeUtil.SetMockTime(0);
             rateLimiter.IsAllowed(ue);
             TimeUtil.SetMockTime(rateLimiter.uniqueExceptionTimePeriodSec - 0.01f);
-
             Assert.IsFalse(rateLimiter.IsAllowed(ue));
-
             //clean up
             TimeUtil.Clean();
         }
@@ -687,13 +715,10 @@ namespace EmbraceSDK.Tests
         {
             UnhandledExceptionRateLimiting rateLimiter = new UnhandledExceptionRateLimiting();
             UnhandledException ue = new UnhandledException("Test", "stackTrace test");
-
             TimeUtil.SetMockTime(0);
             rateLimiter.IsAllowed(ue);
             TimeUtil.SetMockTime(rateLimiter.uniqueExceptionTimePeriodSec + 1);
-
             Assert.IsTrue(rateLimiter.IsAllowed(ue));
-
             //clean up
             TimeUtil.Clean();
         }
@@ -702,24 +727,18 @@ namespace EmbraceSDK.Tests
         public void UnhandledExceptionRateLimitingExceptions_WindowCountExceeded()
         {
             UnhandledExceptionRateLimiting rateLimiter = new UnhandledExceptionRateLimiting();
-
             UnhandledException ue = new UnhandledException("Test0", "stackTrace test0");
             TimeUtil.SetMockTime(0);
             rateLimiter.IsAllowed(ue);
-
-
             UnhandledException ue1 = new UnhandledException("Test1", "stackTrace test1");
             TimeUtil.SetMockTime(1);
             rateLimiter.IsAllowed(ue1);
-
             UnhandledException ue2 = new UnhandledException("Test2", "stackTrace test2");
             TimeUtil.SetMockTime(2);
             rateLimiter.IsAllowed(ue2);
-
             UnhandledException ue3 = new UnhandledException("Test3", "stackTrace test3");
             TimeUtil.SetMockTime(3);
             Assert.IsFalse(rateLimiter.IsAllowed(ue3));
-
             //clean up
             TimeUtil.Clean();
         }
@@ -729,13 +748,15 @@ namespace EmbraceSDK.Tests
         {
             const string exceptionMessage = "This is an exception";
             LogAssert.Expect(LogType.Exception, $"Exception: {exceptionMessage}");
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            embrace.StartSDK();
+            embrace.StartSDK(null, false);
             Exception exception = new Exception(exceptionMessage);
             Debug.LogException(exception);
-
             embrace.provider.ReceivedWithAnyArgs().LogUnhandledUnityException("Exception", exceptionMessage, Arg.Any<string>());
         }
 
@@ -749,31 +770,31 @@ namespace EmbraceSDK.Tests
             values.Add(Embrace.__BridgedHTTPMethod(HTTPMethod.PUT));
             values.Add(Embrace.__BridgedHTTPMethod(HTTPMethod.DELETE));
             values.Add(Embrace.__BridgedHTTPMethod(HTTPMethod.PATCH));
-
             Assert.AreEqual(new List<int> {0,1,2,3,4,5},values);
         }
 
         [Test]
         public void GetLastRunEndState_CallsProvider_AfterSdkStarted()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
-            embrace.StartSDK();
-
+            embrace.StartSDK(null, false);
             var state = embrace.GetLastRunEndState();
-
             embrace.provider.Received(1).GetLastRunEndState();
         }
 
         [Test]
         public void GetLastRunEndState_DoesNotCallProvider_BeforeSdkStarted()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             var state = embrace.GetLastRunEndState();
-
             embrace.provider.DidNotReceive().GetLastRunEndState();
             Assert.AreEqual(LastRunEndState.Invalid, state);
         }

--- a/io.embrace.internal/Testing/Edit Mode Tests/UnhandledExceptionTests.cs
+++ b/io.embrace.internal/Testing/Edit Mode Tests/UnhandledExceptionTests.cs
@@ -154,8 +154,10 @@ namespace EmbraceSDK.Tests
         [TestMustExpectAllLogs]
         public void LogUnhandledException_RejectsNullExceptionInstance()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             string stack = Environment.StackTrace;
 
@@ -170,8 +172,10 @@ namespace EmbraceSDK.Tests
         [TestMustExpectAllLogs]
         public void LogUnhandledException_RejectsNullExceptionName()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             const string message = "exception message";
             string stack = Environment.StackTrace;
@@ -186,8 +190,10 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogUnhandledException_ReplacesNullMessage_WithEmptyString()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             const string exceptionName = "Exception";
             string stack = Environment.StackTrace;
@@ -200,8 +206,10 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogUnhandledException_ReplacesNullMessageProperty_WithEmptyString()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             Exception exception = Substitute.For<Exception>();
             exception.Message.Returns((_) => null);
@@ -216,8 +224,10 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogUnhandledException_ReplacesNullStackTrace_WithEmptyString()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             const string exceptionName = "Exception";
             const string exceptionMessage = "test exception message";
@@ -232,8 +242,10 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogUnhandledException_ReplacesNullStackTraceParameter_WithStackTraceProperty()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             const string exceptionMessage = "test exception message";
             string stack = Environment.StackTrace;
@@ -251,8 +263,10 @@ namespace EmbraceSDK.Tests
         [TestMustExpectAllLogs]
         public void LogHandledException_RejectsNullExceptionInstance()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             string stack = Environment.StackTrace;
 
@@ -267,8 +281,10 @@ namespace EmbraceSDK.Tests
         [TestMustExpectAllLogs]
         public void LogHandledException_RejectsNullExceptionName()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             const string message = "exception message";
             string stack = Environment.StackTrace;
@@ -283,8 +299,10 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogHandledException_ReplacesNullMessage_WithEmptyString()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             const string exceptionName = "Exception";
             string stack = Environment.StackTrace;
@@ -297,8 +315,10 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogHandledException_ReplacesNullMessageProperty_WithEmptyString()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             Exception exception = Substitute.For<Exception>();
             exception.Message.Returns((_) => null);
@@ -313,8 +333,10 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogHandledException_ReplacesNullStackTrace_WithEmptyString()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             const string exceptionName = "Exception";
             const string exceptionMessage = "test exception message";
@@ -329,8 +351,10 @@ namespace EmbraceSDK.Tests
         [Test]
         public void LogHandledException_ReplacesNullStackTraceParameter_WithStackTraceProperty()
         {
-            Embrace embrace = Embrace.Create();
-            embrace.provider = Substitute.For<IEmbraceProvider>();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             const string exceptionMessage = "test exception message";
             string stack = Environment.StackTrace;

--- a/io.embrace.internal/Testing/Play Tests/PlayEmbraceTests.cs
+++ b/io.embrace.internal/Testing/Play Tests/PlayEmbraceTests.cs
@@ -9,6 +9,12 @@ namespace EmbraceSDK.Tests
 {
     public class PlayEmbraceTests : IEmbraceTest
     {
+        [SetUp]
+        public void Setup()
+        {
+            Embrace.Stop();
+        }
+        
         /// <summary>
         /// Test if the provider is setup correctly.
         /// </summary>
@@ -16,7 +22,7 @@ namespace EmbraceSDK.Tests
         [UnityTest, Order(1)]
         public IEnumerator ProviderSetup()
         {
-            Embrace embrace = Embrace.Instance;
+            Embrace.Start();
             yield return new WaitForSeconds(1f);
 
 #if UNITY_ANDROID && !UNITY_EDITOR
@@ -24,7 +30,7 @@ namespace EmbraceSDK.Tests
 #elif (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
             Assert.AreEqual(embrace.provider.GetType(), typeof(Embrace_iOS));
 #else
-            Assert.AreEqual(embrace.provider.GetType(), typeof(Embrace_Stub));
+            Assert.AreEqual(Embrace.Instance.provider.GetType(), typeof(Embrace_Stub));
 #endif
             Cleanup();
         }
@@ -36,14 +42,9 @@ namespace EmbraceSDK.Tests
         [UnityTest]
         public IEnumerator OnlyOneInstanceAfterCreate()
         {
-            GameObject tempGo = new GameObject();
-            tempGo.AddComponent<Embrace>();
-
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
-
-            Embrace embrace = Embrace.Create();
-
-            Embrace[] components = GameObject.FindObjectsOfType<Embrace>();
+            EmbraceUnityListener[] components = Object.FindObjectsOfType<EmbraceUnityListener>();
             Assert.AreEqual(components.Length, 1);
             Cleanup();
         }
@@ -55,14 +56,9 @@ namespace EmbraceSDK.Tests
         [UnityTest]
         public IEnumerator OnlyOneInstanceAfterEmbrace_Instance()
         {
-            GameObject tempGo = new GameObject();
-            tempGo.AddComponent<Embrace>();
-
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
-
-            Embrace embrace = Embrace.Instance;
-
-            Embrace[] components = GameObject.FindObjectsOfType<Embrace>();
+            EmbraceUnityListener[] components = Object.FindObjectsOfType<EmbraceUnityListener>();
             Assert.AreEqual(components.Length, 1);
             Cleanup();
         }
@@ -74,16 +70,15 @@ namespace EmbraceSDK.Tests
         [UnityTest]
         public IEnumerator OnlyOneInstance()
         {
-            GameObject tempGo = new GameObject();
-            tempGo.AddComponent<Embrace>();
-
-            GameObject tempGo2 = new GameObject();
-            tempGo2.AddComponent<Embrace>();
-
+            var embrace1 = new Embrace();
+            embrace1.StartSDK();
+            yield return new WaitForSeconds(1f);
+            var embrace2 = new Embrace();
+            embrace2.StartSDK();
             yield return new WaitForSeconds(1f);
 
-            Embrace[] components = GameObject.FindObjectsOfType<Embrace>();
-            Assert.AreEqual(components.Length, 1);
+            EmbraceUnityListener[] components = Object.FindObjectsOfType<EmbraceUnityListener>();
+            Assert.AreEqual(1, components.Length);
             Cleanup();
         }
 
@@ -94,10 +89,8 @@ namespace EmbraceSDK.Tests
         [UnityTest]
         public IEnumerator InstanceFromStart()
         {
-            GameObject tempGo = new GameObject();
-            Embrace embrace = tempGo.AddComponent<Embrace>();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
-
             Assert.IsNotNull(Embrace.Instance);
             Cleanup();
         }
@@ -109,6 +102,7 @@ namespace EmbraceSDK.Tests
         [UnityTest]
         public IEnumerator EmbraceInstance()
         {
+            Embrace.Start();
             Embrace embrace = Embrace.Instance;
             yield return new WaitForFixedUpdate();
             Assert.IsNotNull(embrace);
@@ -122,17 +116,16 @@ namespace EmbraceSDK.Tests
         [UnityTest]
         public IEnumerator StartSDKBeforeInitialize()
         {
-            GameObject tempGo = new GameObject();
-            Embrace embrace = tempGo.AddComponent<Embrace>();
+            Embrace embrace = new Embrace();
             embrace.StartSDK();
             yield return new WaitForFixedUpdate();
-            Assert.IsNotNull(embrace);
+            Assert.IsNotNull(embrace.listener);
             Cleanup();
         }
 
         public void Cleanup()
         {
-            UnityEngine.Object.DestroyImmediate(Embrace.Instance.gameObject);
+            UnityEngine.Object.DestroyImmediate(Embrace.Instance.listener);
         }
     }
 }

--- a/io.embrace.internal/Testing/Play Tests/PlaySetupTests.cs
+++ b/io.embrace.internal/Testing/Play Tests/PlaySetupTests.cs
@@ -24,13 +24,16 @@ namespace EmbraceSDK.Tests
         [UnityTest]
         public IEnumerator TestSetup()
         {
-            ProviderSetup();
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
 
             yield return LoadScene(DemoConstants.SCENE_NAME_DEMO_HOME, waitSeconds: .25f);
             
 #if DeveloperMode && UNITY_IOS
             // This setup is for Embrace Developer Mode on iOS only.
-            Embrace.Instance.provider.Received().StartSDK(new EmbraceStartupArgs(AppId, 
+            embrace.provider.Received().StartSDK(new EmbraceStartupArgs(AppId, 
                 EmbraceConfig.Default,
                 AppGroupId.Length > 0 ? AppGroupId : null, 
                 BaseUrl, 
@@ -38,10 +41,10 @@ namespace EmbraceSDK.Tests
                 ConfigBaseUrl));
 #elif UNITY_IOS
             // This setup is for Embrace on iOS only.
-            Embrace.Instance.StartSDK(new EmbraceStartupArgs(AppId, EmbraceConfig.Default, null, null, null, null));
+            embrace.StartSDK(new EmbraceStartupArgs(AppId, EmbraceConfig.Default, null, null, null, null));
 #else
             // This setup is for Embrace on Android.
-            Embrace.Instance.StartSDK();
+            embrace.StartSDK();
 #endif
 
             Cleanup();

--- a/io.embrace.internal/Testing/Play Tests/PlayStubTests.cs
+++ b/io.embrace.internal/Testing/Play Tests/PlayStubTests.cs
@@ -11,11 +11,17 @@ namespace EmbraceSDK.Tests
 
     public class PlayStubTests
     {
+        [SetUp]
+        public void Setup()
+        {
+            Embrace.Stop();
+        }
+        
         [UnityTest]
         public IEnumerator InitializeSDK()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: InitializeSDK");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.provider.InitializeSDK();
         }
@@ -25,7 +31,7 @@ namespace EmbraceSDK.Tests
         {
             string identifier = "test";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: SetUserIdentifier {identifier}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.SetUserIdentifier(identifier);
         }
@@ -34,7 +40,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator ClearUserIdentifier()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: ClearUserIdentifier");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.ClearUserIdentifier();
         }
@@ -44,7 +50,7 @@ namespace EmbraceSDK.Tests
         {
             string username = "username";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: SetUsername {username}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.SetUsername(username);
         }
@@ -53,7 +59,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator ClearUsername()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: ClearUsername");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.ClearUsername();
         }
@@ -63,7 +69,7 @@ namespace EmbraceSDK.Tests
         {
             string email = "email@test.com";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: SetUserEmail {email}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.SetUserEmail(email);
         }
@@ -72,7 +78,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator ClearUserEmail()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: ClearUserEmail");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.ClearUserEmail();
         }
@@ -81,7 +87,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator SetUserAsPayer()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: SetUserAsPayer");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.SetUserAsPayer();
         }
@@ -90,7 +96,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator ClearUserAsPayer()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: ClearUserAsPayer");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.ClearUserAsPayer();
         }
@@ -100,7 +106,7 @@ namespace EmbraceSDK.Tests
         {
             string persona = "test persona";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: AddUserPersona {persona}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.AddUserPersona(persona);
         }
@@ -110,7 +116,7 @@ namespace EmbraceSDK.Tests
         {
             string persona = "test persona";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: ClearUserPersona {persona}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.ClearUserPersona(persona);
         }
@@ -119,7 +125,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator ClearAllUserPersonas()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: ClearAllUserPersonas");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.ClearAllUserPersonas();
         }
@@ -130,7 +136,7 @@ namespace EmbraceSDK.Tests
             string key = "Test Key";
             string value = "Test Value";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: AddSessionProperty key: {key} value: {value}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.AddSessionProperty(key, value, false);
         }
@@ -140,7 +146,7 @@ namespace EmbraceSDK.Tests
         {
             string key = "test key";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: RemoveSessionProperty key: {key}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.RemoveSessionProperty(key);
         }
@@ -149,7 +155,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator GetSessionProperties()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: GetSessionProperties");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Dictionary<string, string> dictionary;
             dictionary = Embrace.Instance.GetSessionProperties();
@@ -163,7 +169,7 @@ namespace EmbraceSDK.Tests
             string severityString = "info";
             string message = "Test Message";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: LogMessage severity: {severityString} message: {message}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.LogMessage(message, EMBSeverity.Info);
         }
@@ -174,7 +180,7 @@ namespace EmbraceSDK.Tests
             string severityString = "warning";
             string message = "Test Message";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: LogMessage severity: {severityString} message: {message}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.LogMessage(message, EMBSeverity.Warning);
         }
@@ -185,7 +191,7 @@ namespace EmbraceSDK.Tests
             string severityString = "error";
             string message = "Test Message";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: LogMessage severity: {severityString} message: {message}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.LogMessage(message, EMBSeverity.Error);
         }
@@ -195,7 +201,7 @@ namespace EmbraceSDK.Tests
         {
             string message = "Test Message";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: AddBreadcrumb {message}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.AddBreadcrumb(message);
         }
@@ -204,7 +210,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator EndSession()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: EndSession");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.EndSession();
         }
@@ -213,7 +219,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator GetDeviceId()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: GetDeviceId");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.GetDeviceId();
         }
@@ -222,7 +228,7 @@ namespace EmbraceSDK.Tests
         public IEnumerator GetCurrentSessionId()
         {
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: GetCurrentSessionId");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.GetCurrentSessionId();
         }
@@ -232,7 +238,7 @@ namespace EmbraceSDK.Tests
         {
             string name = "Test Name";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: StartView {name}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.StartView(name);
         }
@@ -242,7 +248,7 @@ namespace EmbraceSDK.Tests
         {
             string name = "Test Name";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: EndView {name}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.EndView(name);
         }
@@ -256,7 +262,7 @@ namespace EmbraceSDK.Tests
             EmbraceSdkInfo sdkInfo = JsonUtility.FromJson<EmbraceSdkInfo>(targetFile.text);
 
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: Unity Version = {unityVersion} GUID = {guid} Unity-SDK Version= {sdkInfo.version}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.provider.SetMetaData(unityVersion, guid, sdkInfo.version);
         }
@@ -272,7 +278,7 @@ namespace EmbraceSDK.Tests
             int bytesout = 0;
             int code = 0;
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: Network Request: {url} method: {method} start: {startms} end: {endms} bytesin: {bytesin} bytesout: {bytesout}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.RecordCompleteNetworkRequest(url, method, startms, endms, bytesin, bytesout, code);
         }
@@ -286,7 +292,7 @@ namespace EmbraceSDK.Tests
             long endms = 0;
             string error = "Test Error";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: Network Request: {url} method: {method} start: {startms} end: {endms} error: {error}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.RecordIncompleteNetworkRequest(url, method, startms, endms, error);
         }
@@ -298,7 +304,7 @@ namespace EmbraceSDK.Tests
             var iosArgs = new iOSPushNotificationArgs("title", "body", "subtitle", "category", 0);
             var expected = $"Push Notification: title: {iosArgs.title} subtitle: {iosArgs.subtitle} body: {iosArgs.body} category: {iosArgs.category} badge: {iosArgs.badge}";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: {expected}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.RecordPushNotification(iosArgs);
 #elif UNITY_ANDROID
@@ -306,7 +312,7 @@ namespace EmbraceSDK.Tests
                 "id", 0, 0, false, false);
             var expected = $"Push Notification: title: {androidArgs.title} body: {androidArgs.body} topic: {androidArgs.topic} id: {androidArgs.id} notificationPriority: {androidArgs.notificationPriority} messageDeliveredPriority: {androidArgs.messageDeliveredPriority} isNotification: {androidArgs.isNotification} hasData: {androidArgs.hasData}";
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: {expected}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.RecordPushNotification(androidArgs);
 #else
@@ -320,7 +326,7 @@ namespace EmbraceSDK.Tests
             string exceptionMessage = "Test Exception Message";
             string stack = Environment.StackTrace;
             LogAssert.Expect(LogType.Log, $"{EmbraceLogger.LOG_TAG}: Unhandled Exception: Exception : {exceptionMessage} : stack : {stack}");
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             yield return new WaitForFixedUpdate();
             Embrace.Instance.provider.LogUnhandledUnityException("Exception", exceptionMessage, stack);
         }

--- a/io.embrace.internal/Testing/Play Tests/PlayTestBase.cs
+++ b/io.embrace.internal/Testing/Play Tests/PlayTestBase.cs
@@ -9,9 +9,16 @@ namespace EmbraceSDK.Tests
 {
     public class PlayTestBase : IEmbraceTest
     {
-        protected void ProviderSetup(IEmbraceProvider provider = null)
+        protected void ProviderSetup()
         {
-            Embrace.Instance.provider = provider ?? Substitute.For<IEmbraceProvider>();
+            Embrace.Stop();
+            
+            Embrace embrace = new Embrace
+            {
+                provider = Substitute.For<IEmbraceProvider>()
+            };
+            
+            embrace.StartSDK();
         }
 
         protected IEnumerator LoadScene(string sceneName, float waitSeconds = 0f)
@@ -37,7 +44,7 @@ namespace EmbraceSDK.Tests
 
         public void Cleanup()
         {
-            GameObject.DestroyImmediate(Embrace.Instance.gameObject);
+            GameObject.DestroyImmediate(Embrace.Instance.listener);
         }
     }
 }

--- a/io.embrace.sdk/Samples/Demo/Scripts/BreadcrumbDemo.cs
+++ b/io.embrace.sdk/Samples/Demo/Scripts/BreadcrumbDemo.cs
@@ -15,7 +15,7 @@ namespace EmbraceSDK.Demo
 
         private void Start()
         {
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             breadcrumbSendButton.onClick.AddListener(HandleBreadcrumbSendClick);
         }
 

--- a/io.embrace.sdk/Samples/Demo/Scripts/CrashDemo.cs
+++ b/io.embrace.sdk/Samples/Demo/Scripts/CrashDemo.cs
@@ -10,7 +10,7 @@ namespace EmbraceSDK.Demo
     {
         public void Start()
         {
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
         }
 
         public void AccessViolation()

--- a/io.embrace.sdk/Samples/Demo/Scripts/DemoBase.cs
+++ b/io.embrace.sdk/Samples/Demo/Scripts/DemoBase.cs
@@ -9,7 +9,7 @@ namespace EmbraceSDK.Demo
     {
         protected void Awake()
         {
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
 
             #if UNITY_2022_3_OR_NEWER
             var sceneSelector = FindAnyObjectByType<SceneSelector>();

--- a/io.embrace.sdk/Samples/Demo/Scripts/IntegrateDemo.cs
+++ b/io.embrace.sdk/Samples/Demo/Scripts/IntegrateDemo.cs
@@ -29,7 +29,7 @@ namespace EmbraceSDK.Demo
         {
             // Call the start method to enable the SDK. Calling it as early as possible in the launch process ensures capture of the most data possible.
             // Start the SDK
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             startParentSpanButton.onClick.AddListener(StartParentSpan);
             stopParentSpanButton.onClick.AddListener(StopParentSpan);
             startChildFailureSpanButton.onClick.AddListener(RecordFailureChildSpan);

--- a/io.embrace.sdk/Samples/Demo/Scripts/SetupEmbraceDemo.cs
+++ b/io.embrace.sdk/Samples/Demo/Scripts/SetupEmbraceDemo.cs
@@ -21,7 +21,7 @@ namespace EmbraceSDK.Demo
         {
             #if DeveloperMode && UNITY_IOS
             // This setup is for Embrace Developer Mode on iOS only.
-            Embrace.Instance.StartSDK(new EmbraceStartupArgs(AppId, 
+            Embrace.Instance.Start(new EmbraceStartupArgs(AppId, 
                 EmbraceConfig.Default,
                 AppGroupId.Length > 0 ? AppGroupId : null, 
                 BaseUrl.Length > 0 ? BaseUrl : null, 
@@ -32,8 +32,8 @@ namespace EmbraceSDK.Demo
             Embrace.Instance.StartSDK(new EmbraceStartupArgs(AppId, EmbraceConfig.Default, null, null, null, null));
             #else
             // This setup is for Embrace on Android.
-            Embrace.Instance.StartSDK();
-            #endif
+            Embrace.Start();
+#endif
         }
     }
 }

--- a/io.embrace.sdk/Scripts/Embrace.cs
+++ b/io.embrace.sdk/Scripts/Embrace.cs
@@ -148,7 +148,6 @@ namespace EmbraceSDK
         {
             if (_instance != null)
             {
-                EmbraceLogger.LogError("Embrace instance already exists.");
                 return;
             }
             

--- a/io.embrace.sdk/Scripts/Embrace.cs
+++ b/io.embrace.sdk/Scripts/Embrace.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using EmbraceSDK.Editor;
 using EmbraceSDK.Internal;
 using EmbraceSDK.Utilities;
-using JetBrains.Annotations;
 using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
 
@@ -80,7 +79,7 @@ namespace EmbraceSDK
             private set => _instance = value;
         }
 
-        void OnApplicationPause(bool pauseStatus)
+        private void OnApplicationPause(bool pauseStatus)
         {
             if (!pauseStatus) {
                 Provider?.InstallUnityThreadSampler();
@@ -122,6 +121,7 @@ namespace EmbraceSDK
                 Instance.scenesToViewReporter?.Dispose();
             });
             
+            Instance.listener.SetOnApplicationPauseCallback(Instance.OnApplicationPause);
             Object.DontDestroyOnLoad(Instance.listener);
         }
 

--- a/io.embrace.sdk/Scripts/EmbraceApi.cs
+++ b/io.embrace.sdk/Scripts/EmbraceApi.cs
@@ -58,7 +58,8 @@ namespace EmbraceSDK
         /// See Embrace Docs for integration instructions. For compatibility with other SDKs, the Embrace SDK must be initialized after any other SDK.
         /// </summary>
         /// <param name="args">Startup arguments to configure the SDK. REQUIRED on iOS</param>
-        void StartSDK(EmbraceStartupArgs args = null);
+        /// <param name="createListener">If true, creates a unity lifecycle event listener for the SDK. This is required to get info for Unity lifecycle events (Awake, OnDestroy, ect)</param>
+        void StartSDK(EmbraceStartupArgs args = null, bool createListener = true);
 
         /// <summary>
         /// Adds a breadcrumb.

--- a/io.embrace.sdk/Scripts/EmbraceUnityListener.cs
+++ b/io.embrace.sdk/Scripts/EmbraceUnityListener.cs
@@ -6,15 +6,26 @@ namespace EmbraceSDK
     public class EmbraceUnityListener : MonoBehaviour
     {
         private Action _onDestroyCallback;
+        private Action<bool> _onApplicationPauseCallback;
 
         public void SetOnDestroyCallback(Action onDestroyCallback)
         {
             _onDestroyCallback = onDestroyCallback;
         }
         
+        public void SetOnApplicationPauseCallback(Action<bool> onApplicationPauseCallback)
+        {
+            _onApplicationPauseCallback = onApplicationPauseCallback;
+        }
+        
         private void OnDestroy()
         {
             _onDestroyCallback?.Invoke();
+        }
+
+        private void OnApplicationPause(bool pause)
+        {
+            _onApplicationPauseCallback?.Invoke(pause);
         }
     }
 }

--- a/io.embrace.sdk/Scripts/EmbraceUnityListener.cs
+++ b/io.embrace.sdk/Scripts/EmbraceUnityListener.cs
@@ -1,0 +1,20 @@
+using System;
+using UnityEngine;
+
+namespace EmbraceSDK
+{
+    public class EmbraceUnityListener : MonoBehaviour
+    {
+        private Action _onDestroyCallback;
+
+        public void SetOnDestroyCallback(Action onDestroyCallback)
+        {
+            _onDestroyCallback = onDestroyCallback;
+        }
+        
+        private void OnDestroy()
+        {
+            _onDestroyCallback?.Invoke();
+        }
+    }
+}

--- a/io.embrace.sdk/Scripts/EmbraceUnityListener.cs.meta
+++ b/io.embrace.sdk/Scripts/EmbraceUnityListener.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 45f55f7bf90b4d269a033020b1c18be8
+timeCreated: 1746484857

--- a/io.embrace.sdk/Scripts/Embrace_Tests.cs
+++ b/io.embrace.sdk/Scripts/Embrace_Tests.cs
@@ -7,7 +7,7 @@ namespace EmbraceSDK.Tests
     {
         public void RunTests()
         {
-            Embrace.Instance.StartSDK();
+            Embrace.Start();
             Embrace.Instance.SetUserIdentifier("embrace_test_user");
             Embrace.Instance.SetUserIdentifier(null);
             Embrace.Instance.ClearUserIdentifier();

--- a/io.embrace.sdk/Scripts/Networking/NetworkCapture.cs
+++ b/io.embrace.sdk/Scripts/Networking/NetworkCapture.cs
@@ -149,11 +149,11 @@ namespace EmbraceSDK.Networking
                 
                 if (error != string.Empty)
                 {
-                    Embrace.Instance.RecordIncompleteNetworkRequest(request.url, method, pendingRequest.startms, endms, error);
+                    Embrace.Instance?.RecordIncompleteNetworkRequest(request.url, method, pendingRequest.startms, endms, error);
                 }
                 else
                 {
-                    Embrace.Instance.RecordCompleteNetworkRequest(request.url, method, pendingRequest.startms, endms, bytesin, bytesout, code);
+                    Embrace.Instance?.RecordCompleteNetworkRequest(request.url, method, pendingRequest.startms, endms, bytesin, bytesout, code);
                 }
                 #endif
 


### PR DESCRIPTION
## Goal

The Embrace object is no longer a Monobehavior and instead is a normal C# object. I also set it up so that you call Embrace.Start now and locked down the instance a little bit. It's a little stricter, but a little cleaner too.

## Testing

Automated testing and device testing.

## Release Notes

- Embrace is no longer a Monobehavior.
- Embrace now starts with `Embrace.Start()` instead of `Embrace.Instance.StartSDK();`

**WHAT**:<br>
**WHY**:<br>
**WHO**:Ben Bennett<br>
