### PR TITLE
Removed InstallUnityThreadSampler

### DIFF
--- a/io.embrace.sdk/Scripts/Embrace.cs
+++ b/io.embrace.sdk/Scripts/Embrace.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEngine;
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using EmbraceSDK.Editor;
@@ -93,8 +92,8 @@ namespace EmbraceSDK
 
         void OnApplicationPause(bool pauseStatus)
         {
-            if (!pauseStatus) {
-                Provider?.InstallUnityThreadSampler();
+            if (!pauseStatus) 
+            {
 #if UNITY_ANDROID
                 // The behaviors of the native Android SDK and the native iOS SDK have been
                 // demonstrated to be different. Namely, the iOS SDK perpetuates the views

--- a/io.embrace.sdk/Scripts/Embrace_Stub.cs
+++ b/io.embrace.sdk/Scripts/Embrace_Stub.cs
@@ -233,11 +233,6 @@ namespace EmbraceSDK.Editor
             EmbraceLogger.Log( $"Network Request: {url} method: {method} start: {startms} end: {endms} error: {error}");
         }
 
-        void IEmbraceProvider.InstallUnityThreadSampler()
-        {
-            EmbraceLogger.Log("InstallUnityThreadSampler");
-        }
-
         #if UNITY_IOS
         void IEmbraceProvider.RecordPushNotification(iOSPushNotificationArgs iosArgs)
         {

--- a/io.embrace.sdk/Scripts/IEmbraceProvider.cs
+++ b/io.embrace.sdk/Scripts/IEmbraceProvider.cs
@@ -49,7 +49,6 @@ namespace EmbraceSDK.Internal
         void RecordIncompleteNetworkRequest(string url, HTTPMethod method, long startms, long endms, string error);
         void LogUnhandledUnityException(string exceptionName, string exceptionMessage, string stack);
         void LogHandledUnityException(string exceptionName, string exceptionMessage, string stack);
-        void InstallUnityThreadSampler();
         string GetCurrentSessionId();
         string StartSpan(string spanName, string parentSpanId, long startTimeMs);
         bool StopSpan(string spanId, int errorCode, long endTimeMs);

--- a/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
+++ b/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
@@ -118,7 +118,6 @@ namespace EmbraceSDK.Internal
         private const string _logUnhandledUnityExceptionMethod = "logUnhandledUnityException";
         private const string _logHandledUnityExceptionMethod = "logHandledUnityException";
         private const string _initUnityAndroidConnection = "initUnityConnection";
-        private const string _installUnityThreadSampler = "installUnityThreadSampler";
         private const string _GetCurrentSessionId = "getCurrentSessionId";
         private const string _StartSpanMethod = "startSpan";
         private const string _StopSpanMethod = "stopSpan";
@@ -602,23 +601,6 @@ namespace EmbraceSDK.Internal
             }
             
             _embraceUnityInternalSharedInstance.Call(_RecordIncompleteNetworkRequestMethod, url, method.ToString(), startms, endms, null, error, null);
-        }
-
-        void IEmbraceProvider.InstallUnityThreadSampler()
-        {
-            if (!ReadyForCalls())
-            {
-                EmbraceLogger.Log("Unable to install unity thread sampler, Embrace SDK not initialized");
-                return;
-            }
-
-            if (!UnityInternalInterfaceReadyForCalls())
-            {
-                EmbraceLogger.Log("Unable to install unity thread sampler, Embrace SDK not initialized");
-                return;
-            }
-            
-            _embraceUnityInternalSharedInstance.Call(_installUnityThreadSampler);
         }
 
         void IEmbraceProvider.LogUnhandledUnityException(string exceptionName, string exceptionMessage, string stack)

--- a/io.embrace.sdk/Scripts/Native/Embrace_iOS.cs
+++ b/io.embrace.sdk/Scripts/Native/Embrace_iOS.cs
@@ -480,13 +480,6 @@ namespace EmbraceSDK.Internal
             embrace_log_network_request(url, method.ToString(), startms, endms, 0, 0, 0, error);
         }
 
-        void IEmbraceProvider.InstallUnityThreadSampler()
-        {
-            // not supported on iOS yet
-            // No-op
-            EmbraceLogger.LogWarning("InstallUnityThreadSampler is not supported on iOS.");
-        }
-
         void IEmbraceProvider.RecordPushNotification(iOSPushNotificationArgs iosArgs)
         {
             if (IsReadyForCalls() == false)


### PR DESCRIPTION
Since we no longer support ANR thread sampling it doesn't make sense to leave this method in.

## Goal

Begin to remove references to Unity from within the Android SDK

## Testing

Automated Testing

## Release Notes

**WHAT**: Removed Unity Thread Sampler<br>
**WHY**: Removing Unity references from the Android SDK<br>
**WHO**: Ben Bennett<br>
