### PR TITLE
Cat redaction changeover

### DIFF
--- a/.github/actions/unity-test/action.yml
+++ b/.github/actions/unity-test/action.yml
@@ -66,10 +66,12 @@ runs:
       run: |
         make test
     - name: Output Test Results
+      shell: bash
       run: |
         cd ./build/test-results
         cat ./*
     - name: Output Test Logs
+      shell: bash
       run: |
         cd ./build/test-logs
         cat ./*


### PR DESCRIPTION
Changeover of our internal test function to `cat` logs rather than upload them.
