### PR TITLE
Alyssa.syharath/embr 7734 tap capture old input

### DIFF
--- a/io.embrace.sdk/Scripts/EmbraceInputSystemTapListener.cs
+++ b/io.embrace.sdk/Scripts/EmbraceInputSystemTapListener.cs
@@ -1,0 +1,45 @@
+using System;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace EmbraceSDK.Instrumentation
+{
+	public class EmbraceInputSystemTapListener : MonoBehaviour
+	{
+		[SerializeField] EventSystem _eventSystem;
+		EventSystem _EventSystem
+		{
+			get
+			{
+				var retValue = _eventSystem ?? (_eventSystem = FindObjectOfType<EventSystem>());
+
+				if (retValue != null)
+					return retValue;
+
+				throw new System.NullReferenceException("There is no EventSystem in the scene. This system requires an event system");
+			}
+		}
+
+		[SerializeField] GameObject selected;
+
+		void Update()
+		{
+			var sys = this._EventSystem;
+			selected = sys.currentSelectedGameObject;
+
+			if (sys.alreadySelecting)
+			{
+				print("We are now selecting something");
+			}
+		}
+
+		void FixedUpdate()
+		{
+			
+			if (_EventSystem.alreadySelecting)
+			{
+				print("We are now selecting something");
+			}
+		}
+	}
+}

--- a/io.embrace.sdk/Scripts/EmbraceInputSystemTapListener.cs.meta
+++ b/io.embrace.sdk/Scripts/EmbraceInputSystemTapListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8ea25eb570364e06881e34537b8353c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/io.embrace.sdk/Scripts/EmbraceStandaloneInputModule.cs
+++ b/io.embrace.sdk/Scripts/EmbraceStandaloneInputModule.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
+
+namespace EmbraceSDK.Instrumentation
+{
+	public class EmbraceStandaloneInputModule : StandaloneInputModule
+	{
+		/// <summary>
+		/// This property is vital for enabling and disabling tap capture for the input module in order to prevent ending up with PII.
+		/// As a default, it is false to prevent accidental PII capture.
+		/// </summary>
+		[Tooltip("This property is vital for enabling and disabling tap capture for the input module in order to prevent ending up with PII.\nAs a default, it is false to prevent accidental PII capture.")]
+		public bool EmbraceTapCaptureEnabled = false;
+		
+		const string EMBRACE_TAP_SPAN_ID = "emb-ui-tap";
+		const string EMBRACE_VIEW_NAME = "view.name";
+		const string EMBRACE_TAP_COORDS = "tap.coords";
+
+		/// <summary>
+		/// This property allows you to set a custom view name provider for Embrace instrumentation.
+		/// Override the default to provide a specific view name logic, such as using a custom scene name or other identifiers.
+		/// </summary>
+		public IEmbraceViewNameProvider EmbraceViewNameProvider { get; set; } = 
+			new DefaultViewNameProvider();
+
+		/// <summary>
+		/// This property allows you to set a custom game object name provider for Embrace instrumentation.
+		/// Override the default to provide a specific game object name logic, such as using a custom naming convention.
+		/// </summary>
+		public IEmbraceGameObjectNameProvider EmbraceGameObjectNameProvider { get; set; } =
+			new DefaultGameObjectNameProvider();
+		
+		/// <summary>
+		/// This property allows you to set a custom function to provide the tapped name for Embrace instrumentation.
+		/// Override the default to customize how the tapped name is constructed, such as including additional context or formatting.
+		/// </summary>
+		public Func<String, String, String> TappedNameProvider { get; set; } = 
+			(aViewName, aTappedName) => $"{aViewName}:{aTappedName}";
+		
+		public override void Process()
+		{
+			CaptureMouseClick(
+				GetMousePointerEventData().GetButtonState(
+					PointerEventData.InputButton.Left));
+			
+			var touchData = GetTouchPointerEventData(Input.GetTouch(0), out var pressed, out var released);
+			CaptureTouch(touchData, pressed, released);
+			
+			base.Process();
+		}
+
+		void CaptureTouch(PointerEventData eventData, bool pressed, bool released)
+		{
+			if (released)
+			{
+				var pointerUpHandler =
+					ExecuteEvents.GetEventHandler<IPointerClickHandler>(eventData.pointerCurrentRaycast.gameObject);
+
+				if (eventData.eligibleForClick && eventData.pointerPress == pointerUpHandler)
+				{
+					if (EmbraceTapCaptureEnabled)
+					{
+						CaptureTapSpan(
+							eventData,
+							EmbraceGameObjectNameProvider?.GetGameObjectName(pointerUpHandler.gameObject),
+							EmbraceViewNameProvider?.GetViewName());
+					}
+				}
+			}
+		}
+		
+		void CaptureMouseClick(ButtonState buttonState)
+		{
+			var leftData = GetMousePointerEventData().GetButtonState(PointerEventData.InputButton.Left);
+
+			if (leftData.eventData.ReleasedThisFrame())
+			{
+				var pointerUpHandler =
+					ExecuteEvents.GetEventHandler<IPointerClickHandler>(leftData.eventData.buttonData
+						.pointerCurrentRaycast.gameObject);
+				if (leftData.eventData.buttonData.eligibleForClick && 
+				    leftData.eventData.buttonData.pointerPress == pointerUpHandler)
+				{
+					if (EmbraceTapCaptureEnabled)
+					{
+						CaptureTapSpan(
+							buttonState.eventData.buttonData, 
+							EmbraceGameObjectNameProvider?.GetGameObjectName(pointerUpHandler.gameObject),
+							EmbraceViewNameProvider?.GetViewName());
+					}
+				}
+			}
+		}
+
+		void CaptureTapSpan(PointerEventData pointerEventData, string tappedName, string viewName)
+		{
+			var timestamp = new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds();
+
+			Embrace.Instance.RecordCompletedSpan(
+				spanName: EMBRACE_TAP_SPAN_ID,
+				startTimeMs: timestamp,
+				endTimeMs: timestamp,
+				attributes: new Dictionary<string, string>()
+				{
+					{ EMBRACE_VIEW_NAME, TappedNameProvider(viewName, tappedName) }, // This is required for the necessary context for now.
+					{ EMBRACE_TAP_COORDS, $"{pointerEventData.position.x},{pointerEventData.position.y}" },
+				});
+		}
+		
+		private class DefaultViewNameProvider : IEmbraceViewNameProvider
+		{
+			public string GetViewName()
+			{
+				return SceneManager.GetActiveScene().name;
+			}
+
+			public string GetViewName(string defaultValue)
+			{
+				return GetViewName();
+			}
+
+			public void SetViewName(string viewName)
+			{
+				// No-op, as the default view name is derived from the active scene.
+			}
+		}
+		
+		private class DefaultGameObjectNameProvider : IEmbraceGameObjectNameProvider
+		{
+			public string GetGameObjectName(GameObject gameObject)
+			{
+				return gameObject.name;
+			}
+		}
+	}
+}

--- a/io.embrace.sdk/Scripts/EmbraceStandaloneInputModule.cs.meta
+++ b/io.embrace.sdk/Scripts/EmbraceStandaloneInputModule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2afea0f97085048698e233a4d7884e55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/io.embrace.sdk/Scripts/IEmbraceGameObjectNameProvider.cs
+++ b/io.embrace.sdk/Scripts/IEmbraceGameObjectNameProvider.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace EmbraceSDK.Instrumentation
+{
+    public interface IEmbraceGameObjectNameProvider
+    {
+        /// <summary>
+        /// Retrieves the name of a GameObject for Embrace instrumentation.
+        /// </summary>
+        /// <param name="gameObject"></param>
+        /// <returns></returns>
+        public string GetGameObjectName(GameObject gameObject);
+    }
+}

--- a/io.embrace.sdk/Scripts/IEmbraceGameObjectNameProvider.cs.meta
+++ b/io.embrace.sdk/Scripts/IEmbraceGameObjectNameProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 68ece669e51904ea18b8ab33752212b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/io.embrace.sdk/Scripts/IEmbraceMonoBehaviourNameProvider.cs
+++ b/io.embrace.sdk/Scripts/IEmbraceMonoBehaviourNameProvider.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace EmbraceSDK.Instrumentation
+{
+    /// <summary>
+    /// Interface for providing names from for Embrace instrumentation.
+    /// </summary>
+    public interface IEmbraceMonoBehaviourNameProvider
+    {
+        /// <summary>
+        /// Returns the name of the game object from a monobehaviour for Embrace instrumentation.
+        /// </summary>
+        /// <returns></returns>
+        public string GetName();
+    }
+}

--- a/io.embrace.sdk/Scripts/IEmbraceMonoBehaviourNameProvider.cs.meta
+++ b/io.embrace.sdk/Scripts/IEmbraceMonoBehaviourNameProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9134aa9d590ea49129d665acbef4643f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/io.embrace.sdk/Scripts/IEmbraceViewNameProvider.cs
+++ b/io.embrace.sdk/Scripts/IEmbraceViewNameProvider.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace EmbraceSDK.Instrumentation
+{
+    public interface IEmbraceViewNameProvider
+    {
+        /// <summary>
+        /// Sets the name of the current view.
+        /// </summary>
+        void SetViewName(string viewName);
+        
+        /// <summary>
+        /// Provides the name of the current view.
+        /// </summary>
+        /// <returns>The name of the view.</returns>
+        string GetViewName();
+
+        /// <summary>
+        /// Provides the name of the current view, with a fallback to a default value if not available.
+        /// </summary>
+        /// <param name="defaultValue">The default value to return if the view name is not available.</param>
+        /// <returns>The name of the view or the default value.</returns>
+        string GetViewName(string defaultValue);
+    }
+}

--- a/io.embrace.sdk/Scripts/IEmbraceViewNameProvider.cs.meta
+++ b/io.embrace.sdk/Scripts/IEmbraceViewNameProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0dfe46560a05d4769bbe1a0b36f85e66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Goal

Handle old input schema for tap capture purposes from Unity

## Testing

Local testing; would like to add automated tests @benjaben if you have ideas

## Release Notes

Need to document new overrides and tap capture functionality. New EmbraceStandaloneInputModule showcase for customer input module capture override example.

**WHAT**: Unity Tap Capture
**WHY**: Tap coordinates are meaningless to Unity Developers
**WHO**: Unity Legacy Input and UI Customers
