### PR TITLE
Scene Loading Spans

### DIFF
--- a/io.embrace.internal/Testing/Play Tests/SceneManagerOverrideTests.cs
+++ b/io.embrace.internal/Testing/Play Tests/SceneManagerOverrideTests.cs
@@ -14,8 +14,8 @@ namespace EmbraceSDK.Tests
         [UnityTest, Order(1)]
         public IEnumerator SceneManagerOverrideMarksSafeAndUnsafe()
         {
-            Action onSceneLoadStarted = Substitute.For<Action>();
-            Action onSceneLoadFinished = Substitute.For<Action>();
+            Action<string> onSceneLoadStarted = Substitute.For<Action<string>>();
+            Action<string> onSceneLoadFinished = Substitute.For<Action<string>>();
             SceneManagerAPI.overrideAPI = new EmbraceSceneManagerOverride(onSceneLoadStarted, onSceneLoadFinished);
             
             yield return new WaitForSeconds(0.25f);
@@ -24,8 +24,8 @@ namespace EmbraceSDK.Tests
             
             yield return new WaitForSeconds(0.25f);
             
-            onSceneLoadStarted.Received().Invoke();
-            onSceneLoadFinished.Received().Invoke();
+            onSceneLoadStarted.Received().Invoke("");
+            onSceneLoadFinished.Received().Invoke("");
         }
     }
     #endif

--- a/io.embrace.sdk/Editor/Editor Inspector/EmbraceTooltips.cs
+++ b/io.embrace.sdk/Editor/Editor Inspector/EmbraceTooltips.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 namespace EmbraceSDK.EditorView
 {
     public static class EmbraceTooltips
@@ -48,5 +50,6 @@ namespace EmbraceSDK.EditorView
         public const string StartupSpanAppReady = "When enabled, Embrace will capture a span from the time the application starts until the developer calls EmbraceStartupSpans.CallAppReady().";
         public const string StartupSpanFirstSceneLoaded = "When enabled, Embrace will capture a span from the time the application starts until the first scene is loaded.";
         public const string StartupSpanTimeToInteract = "When enabled, Embrace will capture a span from the time the application starts until the developer calls EmbraceStartupSpans.CallTimeToInteract().";
+        public const string SceneLoadSpans = "When enabled, Embrace will automatically capture spans for scene load times.";
     }
 }

--- a/io.embrace.sdk/Editor/Editor Windows/Settings/EmbraceSpansManager.cs
+++ b/io.embrace.sdk/Editor/Editor Windows/Settings/EmbraceSpansManager.cs
@@ -15,6 +15,7 @@ namespace EmbraceSDK.EditorView
         public const string EMBRACE_STARTUP_SPANS_DEFINE = "EMBRACE_STARTUP_SPANS";
         public const string EMBRACE_STARTUP_SPANS_FIRST_SCENE_LOADED_DEFINE = "EMBRACE_STARTUP_SPANS_FIRST_SCENE_LOADED";
         public const string EMBRACE_STARTUP_SPANS_LOADING_COMPLETE_DEFINE = "EMBRACE_STARTUP_SPANS_LOADING_COMPLETE";
+        public const string EMBRACE_SCENE_LOAD_SPANS_DEFINE = "EMBRACE_SCENE_LOAD_SPANS";
         
         [Serializable]
         public struct SpanFlags
@@ -27,19 +28,33 @@ namespace EmbraceSDK.EditorView
         private SpanFlags _spanFlags;
         
         [Tooltip(EmbraceTooltips.StartupSpanCapture)]
-        private bool _enabled;
+        private bool _startupSpansCaptureEnabled;
+        private bool _sceneLoadSpansEnabled;
         
         public override void OnGUI()
         {
             DrawStartupSpans();
             EditorGUILayout.Space();
+            EditorGUILayout.Space();
+            DrawSceneLoadSpans();
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+            
+            if(GUILayout.Button("Apply Settings"))
+            {
+                _scriptingDefineUtil.ToggleSymbol(EMBRACE_STARTUP_SPANS_DEFINE, _startupSpansCaptureEnabled);
+                _scriptingDefineUtil.ToggleSymbol(EMBRACE_STARTUP_SPANS_FIRST_SCENE_LOADED_DEFINE, _spanFlags.RecordFirstSceneLoaded && _startupSpansCaptureEnabled);
+                _scriptingDefineUtil.ToggleSymbol(EMBRACE_STARTUP_SPANS_LOADING_COMPLETE_DEFINE, _spanFlags.RecordLoadingComplete && _startupSpansCaptureEnabled);
+                _scriptingDefineUtil.ToggleSymbol(EMBRACE_SCENE_LOAD_SPANS_DEFINE, _sceneLoadSpansEnabled);
+                _scriptingDefineUtil.ApplyModifiedProperties();
+            }
         }
 
         private void DrawStartupSpans()
         {
             GUILayout.Label("Startup Spans", EditorStyles.boldLabel);
-            _enabled = EditorGUILayout.Toggle(new GUIContent("emb-app-time-to-interact", EmbraceTooltips.StartupSpanCapture), _enabled);
-            EditorGUI.BeginDisabledGroup(!_enabled);
+            _startupSpansCaptureEnabled = EditorGUILayout.Toggle(new GUIContent("emb-app-time-to-interact", EmbraceTooltips.StartupSpanCapture), _startupSpansCaptureEnabled);
+            EditorGUI.BeginDisabledGroup(!_startupSpansCaptureEnabled);
             SpanFlags flags = new SpanFlags
             {
                 RecordFirstSceneLoaded = EditorGUILayout.Toggle(new GUIContent("emb-app-loaded", EmbraceTooltips.StartupSpanFirstSceneLoaded), _spanFlags.RecordFirstSceneLoaded),
@@ -49,21 +64,21 @@ namespace EmbraceSDK.EditorView
             EditorGUILayout.Space();
             _spanFlags = flags;
             EditorGUILayout.HelpBox("When your app is finished loading and your user is ready to start interacting with your app you will need to call Embrace.Instance.EndAppStartup() in your code.", MessageType.Info);
-            
-            if(GUILayout.Button("Apply Settings"))
-            {
-                _scriptingDefineUtil.ToggleSymbol(EMBRACE_STARTUP_SPANS_DEFINE, _enabled);
-                _scriptingDefineUtil.ToggleSymbol(EMBRACE_STARTUP_SPANS_FIRST_SCENE_LOADED_DEFINE, _spanFlags.RecordFirstSceneLoaded && _enabled);
-                _scriptingDefineUtil.ToggleSymbol(EMBRACE_STARTUP_SPANS_LOADING_COMPLETE_DEFINE, _spanFlags.RecordLoadingComplete && _enabled);
-                _scriptingDefineUtil.ApplyModifiedProperties();
-            }
+        }
+        
+        private void DrawSceneLoadSpans()
+        {
+            GUILayout.Label("Scene Load Spans", EditorStyles.boldLabel);
+            _sceneLoadSpansEnabled = EditorGUILayout.Toggle(new GUIContent("Enable Scene Load Spans", EmbraceTooltips.SceneLoadSpans), _sceneLoadSpansEnabled);
+            EditorGUILayout.HelpBox("The Embrace SDK can automatically measure scene load times for you. This is done by overriding Unity's SceneManagerAPI. If you are already using a custom SceneManagerAPI override, this will not work or may conflict.", MessageType.Info);
         }
 
         public override void Initialize(MainSettingsEditor _)
         {
             base.Initialize(mainSettingsEditor);
             _scriptingDefineUtil = new ScriptingDefineUtil();
-            _enabled = _scriptingDefineUtil.CheckIfSettingIsEnabled(EMBRACE_STARTUP_SPANS_DEFINE);
+            _startupSpansCaptureEnabled = _scriptingDefineUtil.CheckIfSettingIsEnabled(EMBRACE_STARTUP_SPANS_DEFINE);
+            _sceneLoadSpansEnabled = _scriptingDefineUtil.CheckIfSettingIsEnabled(EMBRACE_SCENE_LOAD_SPANS_DEFINE);
             _spanFlags = new SpanFlags
             {
                 RecordFirstSceneLoaded = _scriptingDefineUtil.CheckIfSettingIsEnabled(EMBRACE_STARTUP_SPANS_FIRST_SCENE_LOADED_DEFINE),

--- a/io.embrace.sdk/Scripts/EmbraceSceneManagerOverride.cs
+++ b/io.embrace.sdk/Scripts/EmbraceSceneManagerOverride.cs
@@ -16,9 +16,9 @@ namespace EmbraceSDK
         private readonly List<(string sceneName, int sceneBuildIndex)> _scenesCurrentlyBeingLoaded =
             new List<(string sceneName, int sceneBuildIndex)>();
 
-        private readonly Action _onSceneLoadStarted;
-        private readonly Action _onSceneLoadFinished;
-        public EmbraceSceneManagerOverride(Action onSceneLoadStarted, Action onSceneLoadFinished)
+        private readonly Action<string> _onSceneLoadStarted;
+        private readonly Action<string> _onSceneLoadFinished;
+        public EmbraceSceneManagerOverride(Action<string> onSceneLoadStarted, Action<string> onSceneLoadFinished)
         {
             SceneManager.sceneLoaded += OnSceneLoaded;
             _onSceneLoadStarted = onSceneLoadStarted;
@@ -32,7 +32,7 @@ namespace EmbraceSDK
 
             if (_scenesCurrentlyBeingLoaded.Count == 0)
             {
-                _onSceneLoadFinished?.Invoke();
+                _onSceneLoadFinished?.Invoke(scene.name);
             }
         }
 
@@ -52,7 +52,7 @@ namespace EmbraceSDK
             bool mustCompleteNextFrame)
         {
             _scenesCurrentlyBeingLoaded.Add((sceneName, sceneBuildIndex));
-            _onSceneLoadStarted?.Invoke();
+            _onSceneLoadStarted?.Invoke(sceneName);
             return base.LoadSceneAsyncByNameOrIndex(sceneName, sceneBuildIndex, parameters, mustCompleteNextFrame);
         }
     }

--- a/io.embrace.sdk/Scripts/Utilities/EmbraceSpanIdTracker.cs
+++ b/io.embrace.sdk/Scripts/Utilities/EmbraceSpanIdTracker.cs
@@ -11,6 +11,11 @@ namespace EmbraceSDK.Utilities
             return _nameToSpanId.GetValueOrDefault(name);
         }
         
+        public static bool HasSpanId(string name)
+        {
+            return _nameToSpanId.ContainsKey(name);
+        }
+        
         public static void AddSpanId(string name, string spanId)
         {
             _nameToSpanId[name] = spanId;

--- a/io.embrace.sdk/Scripts/Utilities/EmbraceSpanIdTracker.cs
+++ b/io.embrace.sdk/Scripts/Utilities/EmbraceSpanIdTracker.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace EmbraceSDK.Utilities
+{
+    internal static class EmbraceSpanIdTracker
+    {
+        private static readonly Dictionary<string, string> _nameToSpanId = new();
+
+        public static string GetSpanId(string name)
+        {
+            return _nameToSpanId.GetValueOrDefault(name);
+        }
+        
+        public static void AddSpanId(string name, string spanId)
+        {
+            _nameToSpanId[name] = spanId;
+        }
+        
+        public static void RemoveSpanId(string name)
+        {
+            _nameToSpanId.Remove(name);
+        }
+    }
+}

--- a/io.embrace.sdk/Scripts/Utilities/EmbraceSpanIdTracker.cs.meta
+++ b/io.embrace.sdk/Scripts/Utilities/EmbraceSpanIdTracker.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 93157ef34d9b47a6a2e13d20f6413f3d
+timeCreated: 1756410477

--- a/io.embrace.sdk/Scripts/Utilities/SceneLoadMeasurer.cs
+++ b/io.embrace.sdk/Scripts/Utilities/SceneLoadMeasurer.cs
@@ -1,0 +1,39 @@
+using System;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace EmbraceSDK.Utilities
+{
+    public class SceneLoadMeasurer : MonoBehaviour
+    {
+        private string _currentSceneLoadSpanId;
+        
+        private void Awake()
+        {
+            // TODO: Use weaving to determine if the client has already overridden the SceneManagerAPI.
+            // if they have, then add our helper functions to their existing overrides.
+            SceneManagerAPI.overrideAPI = new EmbraceSceneManagerOverride(OnSceneLoadStarted, OnSceneLoadFinished);
+        }
+        
+        private void OnSceneLoadStarted(string sceneName)
+        {
+            if (Embrace.Instance.IsStarted == false)
+            {
+                Debug.LogWarning("Unable to start scene load span because Embrace is not started.");
+                return;
+            }
+
+            _currentSceneLoadSpanId = Embrace.Instance.StartSpan($"Load Scene: {sceneName}", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        }
+
+        private void OnSceneLoadFinished(string sceneName)
+        {
+            if (string.IsNullOrEmpty(_currentSceneLoadSpanId))
+            {
+                return;
+            }
+            
+            Embrace.Instance.StopSpan(_currentSceneLoadSpanId, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        }
+    }
+}

--- a/io.embrace.sdk/Scripts/Utilities/SceneLoadMeasurer.cs
+++ b/io.embrace.sdk/Scripts/Utilities/SceneLoadMeasurer.cs
@@ -38,8 +38,15 @@ namespace EmbraceSDK.Utilities
                 return;
             }
 
-            string spanName = $"Load Scene: {sceneName}";
-            string spanId = Embrace.Instance.StartSpan($"scene-{sceneName}-loaded", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            string spanName = $"scene-{sceneName}-loaded";
+            
+            if (EmbraceSpanIdTracker.HasSpanId(spanName))
+            {
+                Debug.LogWarning($"A scene load span for scene '{sceneName}' is already in progress. This may indicate that a previous scene of the same name load did not finish properly.");
+                return;
+            }
+            
+            string spanId = Embrace.Instance.StartSpan(spanName, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
             EmbraceSpanIdTracker.AddSpanId(spanName, spanId);
         }
 

--- a/io.embrace.sdk/Scripts/Utilities/SceneLoadMeasurer.cs
+++ b/io.embrace.sdk/Scripts/Utilities/SceneLoadMeasurer.cs
@@ -1,18 +1,40 @@
+#if EMBRACE_SCENE_LOAD_SPANS
+
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace EmbraceSDK.Utilities
 {
+    /// <summary>
+    /// Measures scene load times using Unity's SceneManagerAPI override.
+    /// If you are already using a custom SceneManagerAPI override, this will not work or may conflict.
+    /// </summary>
     public static class SceneLoadMeasurer
     {
+        private static List<string> _sceneAllowList;
         private static string _currentSceneLoadSpanId;
+        
+        /// <summary>
+        /// Call this function with a list of scenes you want to measure. If this is not called, all scenes will be measured.
+        /// </summary>
+        /// <param name="sceneAllowList"></param>
+        public static void SetSceneAllowList(List<string> sceneAllowList)
+        {
+            _sceneAllowList = sceneAllowList;
+        }
         
         private static void OnSceneLoadStarted(string sceneName)
         {
             if (Embrace.Instance.IsStarted == false)
             {
                 Debug.LogWarning("Unable to start scene load span because Embrace is not started.");
+                return;
+            }
+
+            if (_sceneAllowList is { Count: > 0 } && _sceneAllowList.Contains(sceneName) == false)
+            {
                 return;
             }
 
@@ -37,3 +59,4 @@ namespace EmbraceSDK.Utilities
         }
     }
 }
+#endif

--- a/io.embrace.sdk/Scripts/Utilities/SceneLoadMeasurer.cs.meta
+++ b/io.embrace.sdk/Scripts/Utilities/SceneLoadMeasurer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3802c7d0418c4afeaf4b37a98e40ba87
+timeCreated: 1755709712


### PR DESCRIPTION
## Goal

Developers can now measure how long it takes to load a scene. They can also set certain scenes in an allow list if they are trying to track down certain load times.

## Testing

Device

## Release Notes

Added automatic scene loading spans with an optional allow list feature

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>
