### PR TITLE
Added `SpanExists` function

### DIFF
--- a/io.embrace.internal/Scripts/ValidationBehavior.cs
+++ b/io.embrace.internal/Scripts/ValidationBehavior.cs
@@ -53,7 +53,11 @@ namespace EmbraceSDK.Internal
 
         void Start()
         {
-            Embrace.Instance.StopSpan(_startSpanId, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            if (string.IsNullOrEmpty(_startSpanId) == false)
+            {
+                Embrace.Instance.StopSpan(_startSpanId, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            }
+            
             StartCoroutine(DoBreadcrumb());
             StartCoroutine(DoRequests());
             StartCoroutine(DoSpans());

--- a/io.embrace.internal/Testing/Play Tests/PlayTestBase.cs
+++ b/io.embrace.internal/Testing/Play Tests/PlayTestBase.cs
@@ -17,6 +17,7 @@ namespace EmbraceSDK.Tests
             {
                 var substitute = Substitute.For<IEmbraceProvider>();
                 substitute.StartSpan(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<long>()).Returns("spanId");
+                Embrace.Instance.provider = substitute;
             }
         }
 

--- a/io.embrace.internal/Testing/Play Tests/PlayTestBase.cs
+++ b/io.embrace.internal/Testing/Play Tests/PlayTestBase.cs
@@ -17,6 +17,7 @@ namespace EmbraceSDK.Tests
             {
                 var substitute = Substitute.For<IEmbraceProvider>();
                 substitute.StartSpan(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<long>()).Returns("spanId");
+                substitute.SpanExists(Arg.Any<string>()).Returns(true);
                 Embrace.Instance.provider = substitute;
             }
         }

--- a/io.embrace.internal/Testing/Play Tests/PlayTestBase.cs
+++ b/io.embrace.internal/Testing/Play Tests/PlayTestBase.cs
@@ -11,7 +11,13 @@ namespace EmbraceSDK.Tests
     {
         protected void ProviderSetup(IEmbraceProvider provider = null)
         {
-            Embrace.Instance.provider = provider ?? Substitute.For<IEmbraceProvider>();
+            Embrace.Instance.provider = provider;
+
+            if (provider == null)
+            {
+                var substitute = Substitute.For<IEmbraceProvider>();
+                substitute.StartSpan(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<long>()).Returns("spanId");
+            }
         }
 
         protected IEnumerator LoadScene(string sceneName, float waitSeconds = 0f)

--- a/io.embrace.sdk/Scripts/Embrace.cs
+++ b/io.embrace.sdk/Scripts/Embrace.cs
@@ -933,6 +933,25 @@ namespace EmbraceSDK
         /// <inheritdoc />
         public bool IsEnabled { get; private set; }
 
+        public bool SpanExists(string spanId)
+        {
+            if (spanId == null)
+            {
+                EmbraceLogger.LogError(EmbraceLogger.GetNullErrorMessage("spanId"));
+                return false;
+            }
+
+            try
+            {
+                return provider.SpanExists(spanId);
+            }
+            catch (Exception e)
+            {
+                EmbraceLogger.LogException(e);
+                return false;
+            }
+        }
+        
         /// <summary>
         /// Create and start a new span.
         /// </summary>
@@ -959,6 +978,12 @@ namespace EmbraceSDK
             if (spanId == null) 
             {
                 EmbraceLogger.LogError("in order to stop a span, " + EmbraceLogger.GetNullErrorMessage("spanId"));
+                return false;
+            }
+
+            if (provider.SpanExists(spanId) == false)
+            {
+                EmbraceLogger.LogError($"Cannot stop span '{spanId}' because it does not exist.");
                 return false;
             }
 

--- a/io.embrace.sdk/Scripts/Embrace.cs
+++ b/io.embrace.sdk/Scripts/Embrace.cs
@@ -981,6 +981,12 @@ namespace EmbraceSDK
                 return false;
             }
 
+            if (spanId == string.Empty)
+            {
+                EmbraceLogger.LogError("in order to stop a span, " + EmbraceLogger.GetEmptyErrorMessage("spanId"));
+                return false;
+            }
+
             if (provider.SpanExists(spanId) == false)
             {
                 EmbraceLogger.LogError($"Cannot stop span '{spanId}' because it does not exist.");

--- a/io.embrace.sdk/Scripts/EmbraceMessages.cs
+++ b/io.embrace.sdk/Scripts/EmbraceMessages.cs
@@ -31,6 +31,7 @@ namespace EmbraceSDK
         public const string LOG_HANDLED_UNITY_EXCEPTION_ERROR = "Unable to log handled Unity exception, Embrace SDK not initialized";
         public const string GET_CURRENT_SESSION_ID_ERROR = "Unable to get current session id, Embrace SDK not initialized";
         public const string RECORD_PUSH_NOTIFICATION_ERROR = "Unable to record push notification, Embrace SDK not initialized";
+        public const string SPAN_EXISTS_ERROR = "Unable to check if span exists, Embrace SDK not initialized";
         public const string START_SPAN_ERROR = "Unable to start span, Embrace SDK not initialized";
         public const string STOP_SPAN_ERROR = "Unable to stop span, Embrace SDK not initialized";
         public const string ADD_SPAN_EVENT_ERROR = "Unable to add span event, Embrace SDK not initialized";

--- a/io.embrace.sdk/Scripts/Embrace_Stub.cs
+++ b/io.embrace.sdk/Scripts/Embrace_Stub.cs
@@ -256,6 +256,12 @@ namespace EmbraceSDK.Editor
             EmbraceLogger.Log($"Handled Exception: {exceptionName} : {exceptionMessage} : stack : {stack}");
         }
         
+        public bool SpanExists(string spanId)
+        {
+            EmbraceLogger.Log($"Span Exists: span ID {spanId}");
+            return true;
+        }
+        
         public string StartSpan(string spanName, string parentSpanId, long startTimeMs)
         {
             EmbraceLogger.Log($"Start Span: span name {spanName} parent span ID: {parentSpanId}" +

--- a/io.embrace.sdk/Scripts/IEmbraceProvider.cs
+++ b/io.embrace.sdk/Scripts/IEmbraceProvider.cs
@@ -56,6 +56,7 @@ namespace EmbraceSDK.Internal
         bool AddSpanAttribute(string spanId, string key, string value);
         bool RecordCompletedSpan(string spanName, long startTimeMs, long endTimeMs, int? errorCode, 
             string parentSpanId, Dictionary<string, string> attributes, EmbraceSpanEvent[] events);
+        bool SpanExists(string spanId);
         #if UNITY_IOS
         void RecordPushNotification(iOSPushNotificationArgs iosArgs);
         #elif UNITY_ANDROID

--- a/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
+++ b/io.embrace.sdk/Scripts/Native/Embrace_Android.cs
@@ -125,6 +125,7 @@ namespace EmbraceSDK.Internal
         private const string _AddSpanAttributeMethod = "addSpanAttribute";
         private const string _RecordCompleteSpanMethod = "recordCompletedSpan";
         private const string _DisableMethod = "disable";
+        private const string _GetSpanMethod = "getSpan";
         private const string _RecordNetworkRequestMethod = "recordNetworkRequest";
         private const string _FromCompletedRequestMethod = "fromCompletedRequest";
         private const string _FromIncompleteRequestMethod = "fromIncompleteRequest";
@@ -709,6 +710,11 @@ namespace EmbraceSDK.Internal
             
             EmbraceSharedInstance.Call(_LogPushNotification, androidArgs.title, androidArgs.body, androidArgs.topic, androidArgs.id,
                 jNotificationPriority, jMessageDeliveredPriority, jIsNotification, jHasData);
+        }
+
+        public bool SpanExists(string spanId)
+        {
+            return EmbraceSharedInstance.Call<AndroidJavaObject>(_GetSpanMethod, spanId) != null;
         }
         
         public string StartSpan(string spanName, string parentSpanId, long startTimeMs)

--- a/io.embrace.sdk/Scripts/Native/Embrace_iOS.cs
+++ b/io.embrace.sdk/Scripts/Native/Embrace_iOS.cs
@@ -148,6 +148,9 @@ namespace EmbraceSDK.Internal
         [DllImport("__Internal")]
         private static extern void embrace_disable();
         
+        [DllImport("__Internal")]
+        private static extern bool embrace_span_exists(string spanId);
+        
         void IEmbraceProvider.InitializeSDK()
         {
             EmbraceLogger.Log(EmbraceMessages.IOS_SDK_INITIALIZED);
@@ -543,6 +546,17 @@ namespace EmbraceSDK.Internal
             }
             
             return embrace_get_session_id().ConvertToString();
+        }
+        
+        bool IEmbraceProvider.SpanExists(string spanId)
+        {
+            if (IsReadyForCalls() == false)
+            {
+                EmbraceLogger.LogError(EmbraceMessages.SPAN_EXISTS_ERROR);
+                return false;
+            }
+            
+            return embrace_span_exists(spanId);
         }
 
         string IEmbraceProvider.StartSpan(string spanName, string parentSpanId, long startTimeMs)

--- a/io.embrace.sdk/Scripts/Utilities/EmbraceLogger.cs
+++ b/io.embrace.sdk/Scripts/Utilities/EmbraceLogger.cs
@@ -116,6 +116,11 @@ namespace EmbraceSDK
         {
             return $"null {objectName} is not allowed through the Embrace SDK.";
         }
+        
+        public static string GetEmptyErrorMessage(string objectName)
+        {
+            return $"empty {objectName} is not allowed through the Embrace SDK.";
+        }
 
         #region Log
         #if EMBRACE_SILENCE_TYPE_LOG

--- a/io.embrace.sdk/iOS/EmbraceUnityiOS/Sources/EmbraceUnityiOS/ExposedAPI.swift
+++ b/io.embrace.sdk/iOS/EmbraceUnityiOS/Sources/EmbraceUnityiOS/ExposedAPI.swift
@@ -373,6 +373,19 @@ public func embrace_log_network_client_error(url: UnsafePointer<CChar>?,
     }
 }
 
+@_cdecl("embrace_span_exists")
+public func embrace_span_exists(spanId: UnsafePointer<CChar>?) -> Bool {
+    guard let spanId else {
+        return false
+    }
+
+    if let _spanid = String(validatingUTF8: spanId) {
+        return EmbraceManager.spanExists(spanId: _spanid)
+    }
+
+    return false
+}
+
 @_cdecl("embrace_start_span")
 public func embrace_start_span(name: UnsafePointer<CChar>?, parentSpanId: UnsafePointer<CChar>?, startTimeMs: Double) -> UnsafeMutablePointer<CChar>? {
     guard let name else {


### PR DESCRIPTION
## Goal

Developers were not receiving feedback when trying to stop a span that didn't exist. This now checks to ensure a span exists and throws if it does not.

## Testing

Since this is woven into the `StopSpan` function it will automatically be called when that function is tested.

## Release Notes

- Added `SpanExists` function to check to see if a span currently exists with the desired `spanId`

**WHAT**:<br>
**WHY**:<br>
**WHO**:<br>
