### PR TITLE
Fix inverted directory existence check in EmbraceEdmUtility

### DIFF
--- a/io.embrace.internal/Testing/Edit Mode Tests/EmbraceEdmUtilityTests.cs
+++ b/io.embrace.internal/Testing/Edit Mode Tests/EmbraceEdmUtilityTests.cs
@@ -101,15 +101,24 @@ namespace EmbraceSDK.Tests
         [Test]
         public void SaveDependenciesFile_WhenDirectoryCreationFails_ShouldLogErrorAndReturnFalse()
         {
-            var invalidPath = "C:/NonexistentDirectory/TestDependenciesFile.xml";
+            // Use an existing file as a path component so CreateDirectory throws on all platforms
+            var blockingFile = Path.GetTempFileName();
+            var invalidPath = Path.Combine(blockingFile, "subdir", "TestDependenciesFile.xml");
             var xmlData = "<root><dependency>TestDependency</dependency></root>";
 
-            var result = EmbraceEdmUtility.SaveDependenciesFile(xmlData, invalidPath);
+            try
+            {
+                var result = EmbraceEdmUtility.SaveDependenciesFile(xmlData, invalidPath);
 
-            Assert.IsFalse(result);
-            Assert.IsFalse(File.Exists(invalidPath));
+                Assert.IsFalse(result);
+                Assert.IsFalse(File.Exists(invalidPath));
 
-            LogAssert.Expect(LogType.Warning,$"{EmbraceLogger.LOG_TAG}: Failed to create the directory for the Embrace dependencies XML file.");
+                LogAssert.Expect(LogType.Warning,$"{EmbraceLogger.LOG_TAG}: Failed to create the directory for the Embrace dependencies XML file.");
+            }
+            finally
+            {
+                File.Delete(blockingFile);
+            }
         }
 
         [Test]

--- a/io.embrace.sdk/Editor/EditorUtilities/EmbraceEdmUtility.cs
+++ b/io.embrace.sdk/Editor/EditorUtilities/EmbraceEdmUtility.cs
@@ -189,7 +189,7 @@ namespace EmbraceSDK.EditorView
                 dependenciesDoc.LoadXml(dependenciesXMLData);
             
                 var directory = Path.GetDirectoryName(filePath);
-                if (directory != null && Directory.Exists(directory))
+                if (directory != null && !Directory.Exists(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }

--- a/io.embrace.sdk/Editor/EditorUtilities/EmbraceEdmUtility.cs
+++ b/io.embrace.sdk/Editor/EditorUtilities/EmbraceEdmUtility.cs
@@ -187,18 +187,13 @@ namespace EmbraceSDK.EditorView
             {
                 var dependenciesDoc = new XmlDocument();
                 dependenciesDoc.LoadXml(dependenciesXMLData);
-            
+
                 var directory = Path.GetDirectoryName(filePath);
                 if (directory != null && !Directory.Exists(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }
-                else
-                {
-                    EmbraceLogger.LogWarning("Failed to create the directory for the Embrace dependencies XML file.");
-                    return false;
-                }
-                
+
                 dependenciesDoc.Save(filePath);
                 EmbraceLogger.Log("Embrace SDK Dependencies XML file has been generated and saved.");
                 return true;
@@ -206,6 +201,11 @@ namespace EmbraceSDK.EditorView
             catch (XmlException ex)
             {
                 EmbraceLogger.LogWarning("Failed to generate the Embrace dependencies XML file.", ex);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                EmbraceLogger.LogWarning("Failed to create the directory for the Embrace dependencies XML file.");
                 return false;
             }
         }


### PR DESCRIPTION
Directory.CreateDirectory was only called when the directory already existed. Add ! so it creates the directory only when it doesn't exist.

Fixes EMBR-12724
