### PR TITLE
Add NOTICE symlink at repo root

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+io.embrace.sdk/NOTICE


### PR DESCRIPTION
## Summary

- Adds a symlink at the repo root `NOTICE -> io.embrace.sdk/NOTICE`
- `io.embrace.sdk/NOTICE` is the canonical location, committed in #192, so it gets bundled with the Unity package
- The root symlink makes it discoverable for anyone browsing the repo

## Test plan
- [ ] Confirm `NOTICE` at root resolves to the correct file (`cat NOTICE` should show the attribution content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)