### PR TITLE
Fix Unity Hub Linux install path for Hub >=3.20.0

### DIFF
--- a/.github/scripts/install_hub_linux.sh
+++ b/.github/scripts/install_hub_linux.sh
@@ -68,7 +68,9 @@ sudo apt-get update
 sudo apt-get install -y unityhub
 
 # Alias to "unity-hub" with default params
-printf '#!/bin/bash\nxvfb-run --auto-servernum /opt/unityhub/unityhub-bin --no-sandbox "$@"\n' | sudo tee /usr/bin/unity-hub >/dev/null
+# Unity Hub >=3.20.0 installs to /usr/lib/unityhub (launcher symlinked at
+# /usr/bin/unityhub), not the old /opt/unityhub/unityhub-bin layout.
+printf '#!/bin/bash\nxvfb-run --auto-servernum unityhub --no-sandbox "$@"\n' | sudo tee /usr/bin/unity-hub >/dev/null
 sudo chmod +x /usr/bin/unity-hub
 
 # Configure


### PR DESCRIPTION
Unity's apt repo now ships Hub 3.20.0, which installs to /usr/lib/unityhub (with /usr/bin/unityhub as the launcher) instead of the old /opt/unityhub/unityhub-bin layout. The unity-hub wrapper we create was hardcoded to the old path, breaking Build and Test CI on Linux with "not found" / exit 127.
