### PR TITLE
Add automated npm publish workflow for Unity SDK

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,0 +1,64 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run `npm publish --dry-run` instead of a real publish.'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  id-token: write   # required for npm provenance attestation
+
+jobs:
+  publish:
+    name: Publish io.embrace.sdk to npm
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node + npm auth
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+          registry-url: https://registry.npmjs.org
+
+      - name: Read package version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./io.embrace.sdk/package.json').version")
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Publish to npm
+        # prepublishOnly (make install_ios_dependencies) runs automatically as
+        # part of `npm publish` — see io.embrace.sdk/package.json.
+        working-directory: io.embrace.sdk
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            npm publish --dry-run
+          else
+            npm publish
+          fi
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run complete for io.embrace.sdk@$VERSION. No package was published."
+          else
+            echo "Published io.embrace.sdk@$VERSION to https://www.npmjs.com/package/io.embrace.sdk"
+          fi

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -34,6 +34,10 @@ jobs:
         id: version
         run: |
           VERSION=$(node -p "require('./io.embrace.sdk/package.json').version")
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'$VERSION' from io.embrace.sdk/package.json is not a valid semantic version" >&2
+            exit 1
+          fi
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION"
 

--- a/README.md
+++ b/README.md
@@ -46,20 +46,14 @@ If you run into any issues building the SDK locally, please reach out on our
 
 ## Publishing to npm
 
+Publishing is automated via the [`Publish to npm`](.github/workflows/publish_npm.yml)
+GitHub Actions workflow. Trigger it manually from the Actions tab against the
+branch/ref you want to publish (optionally as a dry run first).
+
 The iOS symbol upload tools (`run.sh` and `embrace_symbol_upload.darwin`) are
 required for the npm package but are excluded from git via `.gitignore`. Before
 publishing to npm, these dependencies will be automatically downloaded via the
 `prepublishOnly` script, which runs `make install_ios_dependencies`.
-
-To publish to npm:
-
-```bash
-cd io.embrace.sdk
-npm publish
-```
-
-The `prepublishOnly` script will automatically download the required iOS tools
-from https://downloads.embrace.io/embrace_support.zip before packaging.
 
 **Note:** For local development and building, you must manually run `make` from
 the repository root to download iOS dependencies and build the SDK. The


### PR DESCRIPTION
Replaces the manual npm login/publish steps with a workflow_dispatch GitHub Actions job that publishes io.embrace.sdk using a stored NPM_TOKEN secret, mirroring the trigger pattern used by release.yml.
