### PR TITLE
Switch npm publish workflow to trusted publishing

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Update npm
         # Trusted publishing requires npm >=11.5.1.
-        run: npm install -g npm@11.5.1
+        run: npm install -g npm@11.5.1 # zizmor: ignore[adhoc-packages] - pinned version, upgrading npm itself so no lockfile applies
 
       - name: Read package version
         id: version

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -32,9 +32,8 @@ jobs:
           package-manager-cache: false
 
       - name: Update npm
-        # Trusted publishing requires npm >=11.5.1, newer than what some Node
-        # versions bundle by default.
-        run: npm install -g npm@latest
+        # Trusted publishing requires npm >=11.5.1.
+        run: npm install -g npm@11.5.1
 
       - name: Read package version
         id: version

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -11,7 +11,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write   # required for npm provenance attestation
+  id-token: write   # required for npm trusted publishing (OIDC) and provenance
 
 jobs:
   publish:
@@ -24,11 +24,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Node + npm auth
+      - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: lts/*
+          node-version: '>=22.14.0' # minimum for npm trusted publishing support
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Update npm
+        # Trusted publishing requires npm >=11.5.1, newer than what some Node
+        # versions bundle by default.
+        run: npm install -g npm@latest
 
       - name: Read package version
         id: version
@@ -46,8 +52,6 @@ jobs:
         # part of `npm publish` — see io.embrace.sdk/package.json.
         working-directory: io.embrace.sdk
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           if [ "$DRY_RUN" = "true" ]; then

--- a/io.embrace.sdk/package.json
+++ b/io.embrace.sdk/package.json
@@ -8,6 +8,10 @@
   "documentationUrl": "https://embrace.io/docs/unity/",
   "changelogUrl": "https://embrace.io/docs/unity/changelog/",
   "licensesUrl": "https://embrace.io/docs/terms-of-service/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embrace-io/embrace-unity-sdk.git"
+  },
   "keywords": [
     "embrace",
     "crashes",


### PR DESCRIPTION
Removes the NPM_TOKEN secret dependency in favor of npm trusted publishing (OIDC), so only GitHub Actions runs from this repo can publish io.embrace.sdk. Adds the repository field package.json needs for npm to validate the trusted publisher match, and bumps Node/npm to the versions trusted publishing requires.
