### PR TITLE
Add noonat as code owner for EmbraceApi.cs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 .github @embrace-io/opensource-devops @embrace-io/opensource-unity
 
 # API Surface Owners
-io.embrace.sdk/Scripts/EmbraceApi.cs @fractalwrench @bidetofevil
+io.embrace.sdk/Scripts/EmbraceApi.cs @fractalwrench @bidetofevil @noonat


### PR DESCRIPTION
## Summary
- Adds @noonat as a code owner for `io.embrace.sdk/Scripts/EmbraceApi.cs` alongside the existing owners.