### PR TITLE
Fix npm package missing iOS .meta files and orphan NOTICE.meta

### DIFF
--- a/.github/scripts/check_meta_files.py
+++ b/.github/scripts/check_meta_files.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Verify that every file in the npm package has a matching Unity .meta file
+and vice versa.
+
+Unity refuses to import an asset without a .meta file when the package lives
+in the immutable package cache (instead of generating one, as it would for a
+mutable project asset), so a missing .meta breaks every consumer's project.
+An orphan .meta with no matching asset is just dead weight.
+
+Takes the path to a JSON file produced by `npm pack --dry-run --json` (or
+`npm pack --json`).
+"""
+
+import json
+import sys
+from os import path
+
+
+def is_hidden(file_path: str) -> bool:
+    """Mirror Unity's AssetDatabase import rules: any path with a
+    dot-prefixed segment (e.g. .build/, .swiftpm/, .git/) is invisible to
+    Unity, so it's never imported and never needs a .meta file."""
+    return any(part.startswith(".") for part in file_path.split("/"))
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <npm-pack-json-file>", file=sys.stderr)
+        return 2
+
+    with open(sys.argv[1], "r") as f:
+        packs = json.load(f)
+
+    files = [
+        entry["path"]
+        for pack in packs
+        for entry in pack["files"]
+        if not is_hidden(entry["path"])
+    ]
+    file_set = set(files)
+    dir_prefixes = {path.dirname(f) for f in files if path.dirname(f)}
+
+    errors = []
+    for f in files:
+        if f.endswith(".meta"):
+            continue
+        meta = f + ".meta"
+        if meta not in file_set:
+            errors.append(f"missing .meta file: {meta} (asset {f} has none)")
+
+    for f in files:
+        if not f.endswith(".meta"):
+            continue
+        asset = f[: -len(".meta")]
+        if asset in file_set or asset in dir_prefixes:
+            continue
+        errors.append(f"orphan .meta file: {f} (no matching asset {asset})")
+
+    if errors:
+        print(f"Found {len(errors)} packaging problem(s):", file=sys.stderr)
+        for e in sorted(errors):
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(f"OK: all {len(files)} packaged files have matching .meta pairs.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_meta_files.py
+++ b/.github/scripts/check_meta_files.py
@@ -15,6 +15,8 @@ import json
 import sys
 from os import path
 
+META_EXT = ".meta"
+
 
 def is_hidden(file_path: str) -> bool:
     """Mirror Unity's AssetDatabase import rules: any path with a
@@ -42,16 +44,16 @@ def main() -> int:
 
     errors = []
     for f in files:
-        if f.endswith(".meta"):
+        if f.endswith(META_EXT):
             continue
-        meta = f + ".meta"
+        meta = f + META_EXT
         if meta not in file_set:
             errors.append(f"missing .meta file: {meta} (asset {f} has none)")
 
     for f in files:
-        if not f.endswith(".meta"):
+        if not f.endswith(META_EXT):
             continue
-        asset = f[: -len(".meta")]
+        asset = f[: -len(META_EXT)]
         if asset in file_set or asset in dir_prefixes:
             continue
         errors.append(f"orphan .meta file: {f} (no matching asset {asset})")

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -46,6 +46,22 @@ jobs:
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Version: $VERSION"
 
+      - name: Download iOS dependencies
+        # Normally handled by the prepublishOnly script, but the package
+        # contents need to exist on disk before `npm pack` below can inspect
+        # them.
+        run: make install_ios_dependencies
+
+      - name: Validate every packaged file has a matching .meta file
+        # Unity refuses to import an asset with no .meta file when the
+        # package lives in the immutable package cache, so a missing .meta
+        # breaks every consumer's project. Catch that (and orphan .meta
+        # files with no matching asset) before publishing.
+        working-directory: io.embrace.sdk
+        run: |
+          npm pack --dry-run --json --ignore-scripts > /tmp/npm-pack.json
+          python3 ../.github/scripts/check_meta_files.py /tmp/npm-pack.json
+
       - name: Publish to npm
         # prepublishOnly (make install_ios_dependencies) runs automatically as
         # part of `npm publish` — see io.embrace.sdk/package.json.

--- a/.gitignore
+++ b/.gitignore
@@ -132,9 +132,10 @@ InitTestScene*.unity
 io.embrace.sdk/iOS/xcframeworks/*.xcframework/
 io.embrace.sdk/iOS/xcframeworks.meta
 
-# The trailing * on the lines below captures both the target file and the associated meta file
-io.embrace.sdk/iOS/embrace_symbol_upload*
-io.embrace.sdk/iOS/run.sh*
+# Downloaded at build/publish time; not committed. Their .meta files ARE
+# committed (no trailing * here) so npm packs a valid pair for each.
+io.embrace.sdk/iOS/embrace_symbol_upload.darwin
+io.embrace.sdk/iOS/run.sh
 io.embrace.sdk/iOS/upload*
 
 # These were added by Xcode's Swift package template.

--- a/io.embrace.sdk/iOS/embrace_symbol_upload.darwin.meta
+++ b/io.embrace.sdk/iOS/embrace_symbol_upload.darwin.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 343fd6a0e63d14a4a8f4645f8cfa1bd8
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/io.embrace.sdk/iOS/run.sh.meta
+++ b/io.embrace.sdk/iOS/run.sh.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 971cc29c8e0f74beb8661637c28e072b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/io.embrace.sdk/package.json
+++ b/io.embrace.sdk/package.json
@@ -37,7 +37,8 @@
     "iOS/embrace_symbol_upload.darwin",
     "*.meta",
     "!Tests.meta",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "NOTICE"
   ],
   "hideInEditor": false,
   "type": "library",


### PR DESCRIPTION
## Summary
- `iOS/run.sh` and `iOS/embrace_symbol_upload.darwin` shipped in the npm package without their `.meta` files, and `NOTICE.meta` shipped with no `NOTICE` file. Unity can't generate missing metas for packages in its immutable package cache, so it errors on every domain reload instead.
- Cause: `.gitignore` ignored the two iOS binaries with a trailing `*`, sweeping up their `.meta` siblings too, so they could never be committed; `package.json`'s `files` allowlist never listed `NOTICE`, only matched it via `*.meta`.

## Changes
- `.gitignore`: only ignore the binaries, not their `.meta` files.
- Restored `iOS/run.sh.meta` and `iOS/embrace_symbol_upload.darwin.meta` with the same GUIDs used in 2.8.1 (pulled from the published tarball) to avoid GUID churn.
- Added `NOTICE` to `package.json`'s `files` array.
- Added `.github/scripts/check_meta_files.py`, run from `publish_npm.yml`, which packs the tarball and fails the workflow if any file is missing its `.meta` or any `.meta` is orphaned.

## Test plan
- [x] Verified the new check catches all 3 problems against a clean checkout of `main` (pre-fix)
- [x] Verified the check passes clean with this branch's changes
- [x] Verified restored `.meta` files are byte-for-byte identical to the ones in the published `io.embrace.sdk@2.8.1` tarball
- [ ] After merge, cut a patch release and confirm a clean `npm pack --dry-run` shows no missing/orphan `.meta` files
- [ ] Confirm importing the patched package into a fresh Unity project produces no `Asset ... has no meta file` console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
